### PR TITLE
feat/copy to clipboard

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -117,6 +117,38 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         })();
         return true; // Indicates async response
     }
+
+    if (request.action === 'COPY_CHAT') {
+        if (!activeParser) {
+            sendResponse({ success: false, error: 'No parser available' });
+            return true;
+        }
+
+        const formatter = formatters[request.format];
+        if (!formatter) {
+            sendResponse({ success: false, error: 'Invalid format' });
+            return true;
+        }
+
+        (async () => {
+            try {
+                const conversation = await activeParser.parse();
+                console.log(
+                    'Parsed conversation with',
+                    conversation.messages.length,
+                    'messages'
+                );
+                sendResponse({
+                    success: true,
+                    content: formatter.format(conversation)
+                });
+            } catch (e) {
+                console.error(e);
+                sendResponse({ success: false, error: e.message });
+            }
+        })();
+        return true;
+    }
 });
 
 // Initial detection

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -56,6 +56,11 @@ h1 {
   gap: 10px;
 }
 
+.button-row {
+  display: flex;
+  gap: 8px;
+}
+
 select {
   padding: 8px;
   border-radius: 6px;
@@ -67,6 +72,7 @@ select {
   background-color: #3498db;
   color: white;
   border: none;
+  flex: 1;
   padding: 10px;
   border-radius: 6px;
   font-size: 14px;
@@ -79,9 +85,27 @@ select {
   background-color: #2980b9;
 }
 
-.primary-btn:disabled {
+.primary-btn:disabled,
+.secondary-btn:disabled {
   background-color: #bdc3c7;
   cursor: not-allowed;
+}
+
+.secondary-btn {
+  background-color: #ecf0f1;
+  color: #2c3e50;
+  border: 1px solid #bdc3c7;
+  flex: 1;
+  padding: 10px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.secondary-btn:hover {
+  background-color: #dfe6e9;
 }
 
 .error {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -23,7 +23,10 @@
           <option value="json" disabled>JSON (Coming Soon)</option>
           <option value="pdf" disabled>PDF (Coming Soon)</option>
         </select>
-        <button id="export-btn" class="primary-btn">Export Chat</button>
+        <div class="button-row">
+          <button id="export-btn" class="primary-btn">Export Chat</button>
+          <button id="copy-btn" class="secondary-btn hidden">Copy to Clipboard</button>
+        </div>
       </div>
 
       <div class="error hidden" id="error-msg">

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -6,7 +6,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   const chatTitleEl = document.getElementById("chat-title");
   const msgCountEl = document.getElementById("message-count");
   const exportBtn = document.getElementById("export-btn");
+  const copyBtn = document.getElementById("copy-btn");
   const formatSelect = document.getElementById("format-select");
+  const copyableFormats = new Set(["markdown", "json"]);
 
   // Get current tab
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -60,10 +62,17 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   await checkAvailability();
 
+  function updateCopyButtonVisibility() {
+    copyBtn.classList.toggle("hidden", !copyableFormats.has(formatSelect.value));
+  }
+
   function showError() {
     statusEl.textContent = "Not Supported";
     errorEl.classList.remove("hidden");
   }
+
+  formatSelect.addEventListener("change", updateCopyButtonVisibility);
+  updateCopyButtonVisibility();
 
   exportBtn.addEventListener("click", async () => {
     const format = formatSelect.value;
@@ -87,6 +96,31 @@ document.addEventListener("DOMContentLoaded", async () => {
     } finally {
       exportBtn.disabled = false;
       exportBtn.textContent = "Export Chat";
+    }
+  });
+
+  copyBtn.addEventListener("click", async () => {
+    const format = formatSelect.value;
+    copyBtn.disabled = true;
+    copyBtn.textContent = "Copying...";
+
+    try {
+      const response = await chrome.tabs.sendMessage(tab.id, {
+        action: "COPY_CHAT",
+        format: format,
+      });
+
+      if (response && response.success) {
+        await navigator.clipboard.writeText(response.content);
+        statusEl.textContent = "Copied to Clipboard!";
+      } else {
+        statusEl.textContent = "Copy Failed: " + (response?.error || "Unknown");
+      }
+    } catch (e) {
+      statusEl.textContent = "Error: " + e.message;
+    } finally {
+      copyBtn.disabled = false;
+      copyBtn.textContent = "Copy to Clipboard";
     }
   });
 });

--- a/tests/popup-copy-button.test.js
+++ b/tests/popup-copy-button.test.js
@@ -15,9 +15,14 @@ test("popup sends a COPY_CHAT message for clipboard actions", () => {
 });
 
 test("copy button is enabled for markdown and json formats only", () => {
-  assert.match(
-    popupJs,
-    /copyableFormats\s*=\s*new Set\(\["markdown", "json"\]\)/,
+  const copyableFormatsMatch = popupJs.match(
+    /copyableFormats\s*=\s*new Set\(\[([\s\S]*?)\]\)/,
   );
-  assert.doesNotMatch(popupJs, /copyableFormats\s*=\s*new Set\([^)]*"pdf"/);
+
+  assert.ok(copyableFormatsMatch, "copyableFormats Set should be defined");
+
+  const copyableFormatsSource = copyableFormatsMatch[1];
+  assert.match(copyableFormatsSource, /["']markdown["']/);
+  assert.match(copyableFormatsSource, /["']json["']/);
+  assert.doesNotMatch(copyableFormatsSource, /["']pdf["']/);
 });

--- a/tests/popup-copy-button.test.js
+++ b/tests/popup-copy-button.test.js
@@ -1,0 +1,23 @@
+const fs = require("node:fs");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const popupHtml = fs.readFileSync("popup/popup.html", "utf8");
+const popupJs = fs.readFileSync("popup/popup.js", "utf8");
+
+test("popup includes a copy button next to export", () => {
+  assert.match(popupHtml, /id="copy-btn"/);
+  assert.match(popupHtml, /Copy to Clipboard/);
+});
+
+test("popup sends a COPY_CHAT message for clipboard actions", () => {
+  assert.match(popupJs, /action:\s*"COPY_CHAT"/);
+});
+
+test("copy button is enabled for markdown and json formats only", () => {
+  assert.match(
+    popupJs,
+    /copyableFormats\s*=\s*new Set\(\["markdown", "json"\]\)/,
+  );
+  assert.doesNotMatch(popupJs, /copyableFormats\s*=\s*new Set\([^)]*"pdf"/);
+});


### PR DESCRIPTION
# Add copy-to-clipboard support for Markdown exports

## Summary

- Add a `Copy to Clipboard` action beside `Export Chat` for Markdown exports.
- Wire clipboard copy through the existing parser and formatter pipeline with a new `COPY_CHAT` message.
- Gate the copy button to Markdown and future JSON formats while keeping PDF export-only (might want to look at better way for formats to *subscribe* to this option, but maybe YAGNI?).
- Add a lightweight popup regression test for the copy button visibility and message action.

Tested on Firefox.

<img width="692" height="586" alt="image" src="https://github.com/user-attachments/assets/fc29fac8-a61f-414c-8936-ea6742c13f8e" />
