### PR TITLE
fix(chatgpt): collect virtualized turns during export

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -50,7 +50,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             // return true to indicate async response
             (async () => {
                 try {
-                    const conversation = await activeParser.parse();
+                    const conversation = await activeParser.parse({ full: false });
                     console.log('Parsed conversation with', conversation.messages.length, 'messages');
                     sendResponse({
                         available: true,
@@ -86,7 +86,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
         (async () => {
             try {
-                const conversation = await activeParser.parse();
+                const conversation = await activeParser.parse({ full: true });
                 console.log('Parsed conversation with', conversation.messages.length, 'messages');
                 const content = formatter.format(conversation);
                 const blob = new Blob([content], { type: formatter.getMimeType() });

--- a/content/parsers/chatgpt.js
+++ b/content/parsers/chatgpt.js
@@ -16,6 +16,11 @@ export class ChatGPTParser extends ChatParser {
         return container.querySelector?.('[data-message-author-role]') || null;
     }
 
+    getRoleElements(container) {
+        if (container.matches?.('[data-message-author-role]')) return [container];
+        return Array.from(container.querySelectorAll?.('[data-message-author-role]') || []);
+    }
+
     getMessageRole(container, roleElement) {
         const roleAttr = roleElement?.getAttribute('data-message-author-role');
         if (roleAttr) return roleAttr === 'user' ? 'User' : 'ChatGPT';
@@ -38,6 +43,20 @@ export class ChatGPTParser extends ChatParser {
         }
 
         return roleElement || (container.matches?.('article') ? container : null);
+    }
+
+    getContentElements(container, roleElements) {
+        const contentElements = [];
+
+        roleElements.forEach(roleElement => {
+            const contentElement = this.getContentElement(roleElement, roleElement);
+            if (contentElement) contentElements.push(contentElement);
+        });
+
+        if (contentElements.length > 0) return contentElements;
+
+        const fallback = this.getContentElement(container, roleElements[0]);
+        return fallback ? [fallback] : [];
     }
 
     cleanContent(content) {
@@ -139,19 +158,29 @@ export class ChatGPTParser extends ChatParser {
         return `${content}\n\n**Attachments & Images:**\n${attachmentLines.join('\n')}`;
     }
 
+    convertContentElement(contentElement) {
+        return convertToMarkdown(contentElement);
+    }
+
     extractMessage(container) {
-        const roleElement = this.getRoleElement(container);
-        const contentElement = this.getContentElement(container, roleElement);
-        if (!contentElement) return null;
+        const roleElements = this.getRoleElements(container);
+        const roleElement = roleElements[0] || this.getRoleElement(container);
+        const contentElements = this.getContentElements(container, roleElements);
+        if (contentElements.length === 0) return null;
 
         const role = this.getMessageRole(container, roleElement);
-        const clone = contentElement.cloneNode(true);
         const noiseSelectors = ['.flex.gap-2', 'button', '.sr-only', '[role="button"]'];
-        noiseSelectors.forEach(selector => {
-            clone.querySelectorAll(selector).forEach(node => node.remove());
-        });
+        const contentParts = contentElements
+            .map(contentElement => {
+                const clone = contentElement.cloneNode(true);
+                noiseSelectors.forEach(selector => {
+                    clone.querySelectorAll(selector).forEach(node => node.remove());
+                });
+                return this.cleanContent(this.convertContentElement(clone));
+            })
+            .filter(Boolean);
 
-        let content = this.cleanContent(convertToMarkdown(clone));
+        let content = contentParts.join('\n\n');
         content = this.appendAttachments(
             content,
             this.extractAttachments(container),

--- a/content/parsers/chatgpt.js
+++ b/content/parsers/chatgpt.js
@@ -1,12 +1,196 @@
 import { ChatParser } from './base.js';
 import { convertToMarkdown } from '../utils/html-to-markdown.js';
+import {
+    collectMountedTurnMessages,
+    findChatGPTScrollRoot,
+    getConversationTurns
+} from './chatgpt_scroll_collector.js';
 
 export class ChatGPTParser extends ChatParser {
     isAvailable(url) {
         return url.includes('chatgpt.com');
     }
 
-    async parse() {
+    getRoleElement(container) {
+        if (container.matches?.('[data-message-author-role]')) return container;
+        return container.querySelector?.('[data-message-author-role]') || null;
+    }
+
+    getMessageRole(container, roleElement) {
+        const roleAttr = roleElement?.getAttribute('data-message-author-role');
+        if (roleAttr) return roleAttr === 'user' ? 'User' : 'ChatGPT';
+
+        const text = container.innerText || '';
+        if (text.startsWith('You\n') || text.includes('\nYou\n')) return 'User';
+
+        return 'ChatGPT';
+    }
+
+    getContentElement(container, roleElement) {
+        if (roleElement?.getAttribute('data-message-author-role') === 'user') {
+            return roleElement;
+        }
+
+        const selectors = ['.markdown', '.prose', '.whitespace-pre-wrap'];
+        for (const selector of selectors) {
+            const contentElement = container.querySelector?.(selector);
+            if (contentElement) return contentElement;
+        }
+
+        return roleElement || (container.matches?.('article') ? container : null);
+    }
+
+    cleanContent(content) {
+        return content
+            .replace(/^Show moreShow less$/gm, '')
+            .replace(/\n{3,}/g, '\n\n')
+            .trim();
+    }
+
+    getMessageKey(container, roleElement, role, content) {
+        const idElement = roleElement?.closest?.('[data-message-id]') ||
+            container.querySelector?.('[data-message-id]');
+        const messageId = idElement?.getAttribute('data-message-id');
+        if (messageId) return messageId;
+
+        const turnId = container.getAttribute?.('data-testid');
+        if (turnId) return `${turnId}:${role}`;
+
+        return `${role}:${content.replace(/\s+/g, ' ').trim()}`;
+    }
+
+    extractAttachments(container) {
+        const attachments = [];
+        const rawContent = container.textContent || container.innerText || '';
+        const filePatterns = [
+            /([a-zA-Z0-9_-]+\.tex)/g,
+            /([a-zA-Z0-9_-]+\.txt)/g,
+            /([a-zA-Z0-9_-]+\.md)/g,
+            /([a-zA-Z0-9_-]+\.pdf)/g,
+            /([a-zA-Z0-9_-]+\.doc)/g
+        ];
+        const foundFiles = new Set();
+
+        filePatterns.forEach(pattern => {
+            const matches = rawContent.match(pattern);
+            if (matches) matches.forEach(match => foundFiles.add(match));
+        });
+
+        foundFiles.forEach(fileName => {
+            const fileExt = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
+            const typeMap = {
+                tex: 'LaTeX',
+                txt: 'Text',
+                md: 'Markdown',
+                pdf: 'PDF',
+                doc: 'Document',
+                docx: 'Document'
+            };
+            attachments.push({ name: fileName, type: typeMap[fileExt] || 'File' });
+        });
+
+        return attachments;
+    }
+
+    extractImages(container) {
+        const seenSrcs = new Set();
+        const capturedImages = [];
+
+        container.querySelectorAll?.('img').forEach(img => {
+            const src = img.getAttribute('src');
+            const alt = img.getAttribute('alt') || 'Image';
+            const isContentImage = src?.includes('backend-api') ||
+                src?.includes('files') ||
+                src?.startsWith('blob:') ||
+                alt.includes('Uploaded') ||
+                alt.includes('Generated');
+
+            if (src && !seenSrcs.has(src) && isContentImage) {
+                seenSrcs.add(src);
+                capturedImages.push(`![${alt}](${src})`);
+            }
+        });
+
+        return capturedImages;
+    }
+
+    appendAttachments(content, attachments, capturedImages) {
+        const attachmentLines = [];
+        const groupedAttachments = {};
+
+        attachments.forEach(attachment => {
+            groupedAttachments[attachment.type] ||= [];
+            groupedAttachments[attachment.type].push(attachment.name);
+        });
+
+        Object.entries(groupedAttachments).forEach(([type, files]) => {
+            attachmentLines.push(`**${type} Files:**`);
+            files.forEach(file => attachmentLines.push(`- ${file}`));
+            attachmentLines.push('');
+        });
+
+        if (capturedImages.length > 0) {
+            if (attachmentLines.length > 0) attachmentLines.push('');
+            attachmentLines.push('**Images:**');
+            capturedImages.forEach(image => attachmentLines.push(`- ${image}`));
+        }
+
+        if (attachmentLines.length === 0) return content;
+        return `${content}\n\n**Attachments & Images:**\n${attachmentLines.join('\n')}`;
+    }
+
+    extractMessage(container) {
+        const roleElement = this.getRoleElement(container);
+        const contentElement = this.getContentElement(container, roleElement);
+        if (!contentElement) return null;
+
+        const role = this.getMessageRole(container, roleElement);
+        const clone = contentElement.cloneNode(true);
+        const noiseSelectors = ['.flex.gap-2', 'button', '.sr-only', '[role="button"]'];
+        noiseSelectors.forEach(selector => {
+            clone.querySelectorAll(selector).forEach(node => node.remove());
+        });
+
+        let content = this.cleanContent(convertToMarkdown(clone));
+        content = this.appendAttachments(
+            content,
+            this.extractAttachments(container),
+            this.extractImages(container)
+        );
+
+        if (!content) return null;
+
+        return {
+            role,
+            content,
+            key: this.getMessageKey(container, roleElement, role, content)
+        };
+    }
+
+    extractMountedMessages() {
+        const articles = Array.from(document.querySelectorAll('article'));
+        const containers = articles.length > 0 ?
+            articles :
+            Array.from(document.querySelectorAll('[data-message-author-role]'));
+
+        return containers
+            .map(container => this.extractMessage(container))
+            .filter(Boolean)
+            .map(({ role, content }) => ({ role, content }));
+    }
+
+    async extractAllConversationTurns() {
+        const turns = getConversationTurns(document);
+        if (turns.length === 0) return [];
+
+        return collectMountedTurnMessages({
+            turns,
+            scrollRoot: findChatGPTScrollRoot(turns, document),
+            extractMessage: turn => this.extractMessage(turn)
+        });
+    }
+
+    async parse(options = {}) {
         const title = document.title || 'ChatGPT Session';
         const messages = [];
 
@@ -129,198 +313,13 @@ export class ChatGPTParser extends ChatParser {
             return { title, messages };
         }
 
-        // Strategy: ChatGPT messages are almost always wrapped in <article> tags.
-        // Identify them by finding all articles in the conversation container.
-        // (Usually main > div > div > div > div...)
-
-        const articles = document.querySelectorAll('article');
-
-        articles.forEach((article, index) => {
-            console.log(`=== Processing article ${index} ===`); // Debug
-            let role = 'Unknown';
-            let content = '';
-
-            // 1. Role Detection
-            // Check for explicit data attribute
-            const roleAttr = article.querySelector('[data-message-author-role]')?.getAttribute('data-message-author-role');
-            if (roleAttr) {
-                role = roleAttr === 'user' ? 'User' : 'ChatGPT';
-            } else {
-                // Heuristic: Check for specific icon containers or classes
-                // User usually has an avatar or specific initials container
-                // Assistant has the SVG logo.
-                // Often, user has .justify-end (right side) or specific layout? No, usually stacked.
-
-                // Try checking for "You" text label in the header part
-                if (article.innerText.startsWith('You\n') || article.innerText.includes('\nYou\n')) {
-                    role = 'User';
-                } else {
-                    role = 'ChatGPT'; // Default to Assistant if not explicitly user
-                }
-            }
-            
-            console.log(`Detected role: ${role}`); // Debug
-
-            // 2. Content Extraction
-            // We want the text content, usually in particular classes.
-            // .markdown is common for Assistant.
-            // User messages are often just text in a div.
-
-            // Try specific content containers
-            const contentCandidates = [
-                '.markdown',
-                '.prose',
-                '[data-message-author-role="user"]', // Sometimes the role element IS the container
-                '.whitespace-pre-wrap'
-            ];
-
-            let contentEl = null;
-            for (const selector of contentCandidates) {
-                contentEl = article.querySelector(selector);
-                if (contentEl) break;
-            }
-
-            // Fallback: Use the article text but try to strip metadata
-            if (!contentEl) {
-                contentEl = article;
-            }
-
-            // 3. Image and File Extraction (MOVED UP - before DOM cleaning)
-            // ChatGPT often includes images (uploaded or generated) and file attachments
-            // We should try to capture both.
-            
-            console.log('=== Starting attachment extraction ==='); // Debug
-            // Extract file attachments using regex from content
-            const attachments = [];
-            
-            // Get the raw text content to find file names
-            const rawContent = article.textContent || article.innerText;
-            console.log('Raw content:', rawContent.substring(0, 200)); // Debug
-            
-            // Match file extensions in the content
-            const filePatterns = [
-                /([a-zA-Z0-9_\-]+\.tex)/g,
-                /([a-zA-Z0-9_\-]+\.txt)/g,
-                /([a-zA-Z0-9_\-]+\.md)/g,
-                /([a-zA-Z0-9_\-]+\.pdf)/g,
-                /([a-zA-Z0-9_\-]+\.doc)/g
-            ];
-            
-            const foundFiles = new Set();
-            filePatterns.forEach(pattern => {
-                const matches = rawContent.match(pattern);
-                if (matches) {
-                    matches.forEach(match => {
-                        foundFiles.add(match);
-                    });
-                }
-            });
-            
-            console.log('Found files:', Array.from(foundFiles)); // Debug
-            
-            foundFiles.forEach(fileName => {
-                const fileExt = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
-                
-                // Determine file type
-                let fileType = 'File';
-                if (['tex', 'txt', 'md', 'pdf', 'doc', 'docx'].includes(fileExt)) {
-                    const typeMap = {
-                        'tex': 'LaTeX',
-                        'txt': 'Text', 
-                        'md': 'Markdown',
-                        'pdf': 'PDF',
-                        'doc': 'Document',
-                        'docx': 'Document'
-                    };
-                    fileType = typeMap[fileExt] || 'File';
-                }
-                
-                console.log('Adding attachment:', fileName, fileType); // Debug
-                attachments.push({
-                    name: fileName,
-                    type: fileType
-                });
-            });
-
-            // Common selectors: img.rounded-md, img[src*="backend-api"], or keys like "Uploaded image"
-            const images = article.querySelectorAll('img');
-            const seenSrcs = new Set();
-            const capturedImages = [];
-
-            images.forEach(img => {
-                const src = img.getAttribute('src');
-                const alt = img.getAttribute('alt') || 'Image';
-
-                // Filter out small icons/avatars
-                if (src && !seenSrcs.has(src) && (src.includes('backend-api') || src.includes('files') || src.startsWith('blob:') || alt.includes('Uploaded') || alt.includes('Generated'))) {
-                    seenSrcs.add(src);
-                    capturedImages.push(`![${alt}](${src})`);
-                }
-            });
-
-            // Text Extraction
-            // We need to be careful not to extract "Copy code", "Regenerate", etc.
-            // Cloning the node to clean it up is safer.
-            const clone = contentEl.cloneNode(true);
-
-            // Remove known noise elements (but NOT file tiles)
-            const noiseSelectors = ['.flex.gap-2', 'button', '.sr-only', '[role="button"]'];
-            noiseSelectors.forEach(sel => {
-                clone.querySelectorAll(sel).forEach(n => n.remove());
-            });
-
-            // Convert HTML to markdown to preserve formatting
-            content = convertToMarkdown(clone);
-
-            // Append attachments and images to content
-            const allAttachments = [];
-            
-            if (attachments.length > 0) {
-                // Group by file type for better organization
-                const groupedAttachments = {};
-                attachments.forEach(att => {
-                    if (!groupedAttachments[att.type]) {
-                        groupedAttachments[att.type] = [];
-                    }
-                    groupedAttachments[att.type].push(att.name);
-                });
-                
-                // Create organized attachment list
-                Object.entries(groupedAttachments).forEach(([type, files]) => {
-                    allAttachments.push(`**${type} Files:**`);
-                    files.forEach(file => {
-                        allAttachments.push(`- ${file}`);
-                    });
-                    allAttachments.push(''); // Empty line between file types
-                });
-            }
-            
-            if (capturedImages.length > 0) {
-                if (allAttachments.length > 0) allAttachments.push(''); // Add spacing
-                allAttachments.push('**Images:**');
-                capturedImages.forEach(img => {
-                    allAttachments.push(`- ${img}`);
-                });
-            }
-            
-            if (allAttachments.length > 0) {
-                content = content + '\n\n**Attachments & Images:**\n' + allAttachments.join('\n');
-            }
-
-            if (content) {
-                messages.push({ role, content });
-            }
-        });
-
-        // Fallback: If no articles found (legacy UI or update?), try the old data-message-author-role selector
-        if (messages.length === 0) {
-            const messageElements = document.querySelectorAll('[data-message-author-role]');
-            messageElements.forEach(el => {
-                const role = el.getAttribute('data-message-author-role') === 'user' ? 'User' : 'ChatGPT';
-                const contentEl = el.querySelector('.markdown') || el.querySelector('.prose') || el;
-                messages.push({ role, content: convertToMarkdown(contentEl) });
-            });
-        }
+        const fullExport = options.full !== false;
+        const extractedMessages = fullExport ?
+            await this.extractAllConversationTurns() :
+            this.extractMountedMessages();
+        messages.push(...(extractedMessages.length > 0 ?
+            extractedMessages :
+            this.extractMountedMessages()));
 
         const metadata = {
             'Source': 'ChatGPT',

--- a/content/parsers/chatgpt_scroll_collector.js
+++ b/content/parsers/chatgpt_scroll_collector.js
@@ -1,0 +1,92 @@
+const TURN_SELECTOR = 'section[data-testid^="conversation-turn-"]';
+const DEFAULT_RENDER_WAIT_MS = 160;
+
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isScrollable(element) {
+    return element && element.scrollHeight > element.clientHeight + 80;
+}
+
+function messageKey(message) {
+    if (message.key) return message.key;
+    return `${message.role}:${message.content.replace(/\s+/g, ' ').trim()}`;
+}
+
+function publicMessage(message) {
+    return {
+        role: message.role,
+        content: message.content
+    };
+}
+
+export function getConversationTurnIndex(turn) {
+    const testId = turn.getAttribute('data-testid') || '';
+    const match = testId.match(/^conversation-turn-(\d+)$/);
+    return match ? Number(match[1]) : Number.POSITIVE_INFINITY;
+}
+
+export function getConversationTurns(doc = document) {
+    return Array.from(doc.querySelectorAll(TURN_SELECTOR)).sort((a, b) => {
+        return getConversationTurnIndex(a) - getConversationTurnIndex(b);
+    });
+}
+
+export function findChatGPTScrollRoot(turns, doc = document) {
+    const firstTurn = turns.find(Boolean);
+    let current = firstTurn?.parentElement || null;
+
+    while (current) {
+        if (isScrollable(current)) return current;
+        current = current.parentElement;
+    }
+
+    const main = doc.querySelector('main');
+    if (isScrollable(main)) return main;
+
+    return doc.scrollingElement || doc.documentElement || doc.body;
+}
+
+export async function collectMountedTurnMessages({
+    turns,
+    scrollRoot,
+    extractMessage,
+    waitForRender = delay,
+    renderWaitMs = DEFAULT_RENDER_WAIT_MS,
+    renderAttempts = 4
+}) {
+    const originalTop = scrollRoot?.scrollTop;
+    const seen = new Set();
+    const messages = [];
+    const orderedTurns = [...turns].sort((a, b) => {
+        return getConversationTurnIndex(a) - getConversationTurnIndex(b);
+    });
+
+    try {
+        for (const turn of orderedTurns) {
+            turn.scrollIntoView({ block: 'center' });
+
+            let message = null;
+            for (let attempt = 0; attempt < renderAttempts; attempt += 1) {
+                await waitForRender(renderWaitMs);
+                message = extractMessage(turn);
+                if (message?.content) break;
+            }
+
+            if (!message?.content) continue;
+
+            const key = messageKey(message);
+            if (seen.has(key)) continue;
+
+            seen.add(key);
+            messages.push(publicMessage(message));
+        }
+    } finally {
+        if (scrollRoot && Number.isFinite(originalTop)) {
+            scrollRoot.scrollTop = originalTop;
+        }
+    }
+
+    return messages;
+}

--- a/tests/chatgpt-parser.test.mjs
+++ b/tests/chatgpt-parser.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { ChatGPTParser } from '../content/parsers/chatgpt.js';
+
+class FakeElement {
+  constructor({
+    attributes = {},
+    children = [],
+    html = '',
+    text = '',
+  } = {}) {
+    this.attributes = attributes;
+    this.children = children;
+    this.innerHTML = html;
+    this.textContent = text;
+    this.innerText = text;
+  }
+
+  getAttribute(name) {
+    return this.attributes[name] || null;
+  }
+
+  matches(selector) {
+    return selector === '[data-message-author-role]' &&
+      Boolean(this.attributes['data-message-author-role']);
+  }
+
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+
+  querySelectorAll(selector) {
+    if (selector === '[data-message-author-role]') {
+      return this.children.filter(child => child.matches(selector));
+    }
+
+    if (selector === '.markdown' || selector === '.prose') {
+      return this.children.filter(child => child.attributes.class === selector.slice(1));
+    }
+
+    return [];
+  }
+
+  closest() {
+    return null;
+  }
+
+  cloneNode() {
+    return new FakeElement({
+      attributes: this.attributes,
+      children: this.children,
+      html: this.innerHTML,
+      text: this.textContent,
+    });
+  }
+}
+
+global.HTMLElement = FakeElement;
+
+test('extractMessage combines multiple assistant blocks in one ChatGPT turn', () => {
+  const parser = new ChatGPTParser();
+  parser.convertContentElement = element => element.textContent;
+  const preThinkingMarkdown = new FakeElement({
+    attributes: { class: 'markdown' },
+    html: '<p>I will inspect the provided documents first.</p>',
+    text: 'I will inspect the provided documents first.',
+  });
+  const finalMarkdown = new FakeElement({
+    attributes: { class: 'markdown' },
+    html: '<p>Final answer content after thinking mode.</p>',
+    text: 'Final answer content after thinking mode.',
+  });
+  const turn = new FakeElement({
+    attributes: { 'data-testid': 'conversation-turn-22' },
+    children: [
+      new FakeElement({
+        attributes: { 'data-message-author-role': 'assistant' },
+        children: [preThinkingMarkdown],
+      }),
+      new FakeElement({
+        attributes: { 'data-message-author-role': 'assistant' },
+        children: [finalMarkdown],
+      }),
+    ],
+  });
+
+  const message = parser.extractMessage(turn);
+
+  assert.equal(message.role, 'ChatGPT');
+  assert.equal(
+    message.content,
+    'I will inspect the provided documents first.\n\n' +
+      'Final answer content after thinking mode.'
+  );
+});

--- a/tests/chatgpt-scroll-collector.test.mjs
+++ b/tests/chatgpt-scroll-collector.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  collectMountedTurnMessages,
+  getConversationTurnIndex,
+} from '../content/parsers/chatgpt_scroll_collector.js';
+
+class FakeTurn {
+  constructor(index, message) {
+    this.message = message;
+    this.scrollCount = 0;
+    this.testId = `conversation-turn-${index}`;
+  }
+
+  getAttribute(name) {
+    return name === 'data-testid' ? this.testId : null;
+  }
+
+  scrollIntoView() {
+    this.scrollCount += 1;
+  }
+}
+
+test('getConversationTurnIndex parses ChatGPT turn ids', () => {
+  const turn = new FakeTurn(23, null);
+
+  assert.equal(getConversationTurnIndex(turn), 23);
+});
+
+test('collectMountedTurnMessages scrolls turns and dedupes extracted messages', async () => {
+  const turns = [
+    new FakeTurn(2, { key: 'assistant:hello', role: 'ChatGPT', content: 'hello' }),
+    new FakeTurn(1, { key: 'user:question', role: 'User', content: 'question' }),
+    new FakeTurn(3, { key: 'assistant:hello', role: 'ChatGPT', content: 'hello' }),
+  ];
+  const visited = [];
+  const scrollRoot = { scrollTop: 120 };
+
+  const messages = await collectMountedTurnMessages({
+    turns,
+    scrollRoot,
+    waitForRender: async () => {},
+    extractMessage: (turn) => {
+      visited.push(getConversationTurnIndex(turn));
+      return turn.message;
+    },
+  });
+
+  assert.deepEqual(visited, [1, 2, 3]);
+  assert.deepEqual(messages, [
+    { role: 'User', content: 'question' },
+    { role: 'ChatGPT', content: 'hello' },
+  ]);
+  assert.equal(scrollRoot.scrollTop, 120);
+  assert.deepEqual(turns.map((turn) => turn.scrollCount), [1, 1, 1]);
+});


### PR DESCRIPTION
# fix(chatgpt): collect virtualized turns during export

Closes #4

## Summary

- Add a ChatGPT scroll collector that walks ordered
  `section[data-testid^="conversation-turn-"]` shells, scrolls each turn into
  view, waits for mounted content, dedupes messages, and restores the original
  scroll position.
- Refactor ChatGPT message extraction into shared helpers so mounted-only
  parsing and full export use the same role, content, attachment, image, and
  cleanup logic.
- Keep the popup availability/count path on currently mounted messages with
  `parse({ full: false })`, while the export path uses `parse({ full: true })`
  to collect the full virtualized conversation.
- Clean ChatGPT UI noise such as `Show moreShow less` from exported message
  content and preserve multiple assistant content blocks in one turn.

## Notes

The full ChatGPT export path can visibly scroll the current tab because
ChatGPT only mounts message content for visible conversation regions. The
collector restores the original scroll position after collection completes.

## Testing

- `node --test tests/chatgpt-parser.test.mjs tests/chatgpt-scroll-collector.test.mjs`
