### PR TITLE
Add schema-backed JSON export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 *.log
 node_modules/
 internal/
-publish/ 
+publish/
+/.worktrees

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # AI Chat Exporter
 
-A simple, privacy-focused browser extension to export AI chats from ChatGPT, Claude, Gemini, Qwen, Perplexity, DeepSeek, and Meta AI to Markdown format.
+A simple, privacy-focused browser extension to export AI chats from ChatGPT,
+Claude, Gemini, Qwen, Perplexity, DeepSeek, and Meta AI to Markdown or JSON.
 
 > This extension was developed for personal use and is not very polished. Additionally, formatting of exported items from certain chats is currently not working well.
 
 ## Features
 
-- **Privacy First**: All processing happens locally in your browser. No data is sent to external servers.
+- **Privacy First**: All processing happens locally in your browser.
+  No data is sent to external servers.
 - **Multi-Platform Support**: Works with all major AI chat platforms
   - ChatGPT (chatgpt.com)
   - Claude (claude.ai)
@@ -16,6 +18,7 @@ A simple, privacy-focused browser extension to export AI chats from ChatGPT, Cla
   - DeepSeek (chat.deepseek.com)
   - Meta AI (meta.ai)
 - **Clean Markdown Export**: Properly formatted with code blocks, tables, and attachments preserved
+- **Schema-Based JSON Export**: Normalized JSON exports for predictable downstream use
 - **One-Click Export**: Simple popup interface for quick exports
 
 ## Installation
@@ -25,7 +28,8 @@ A simple, privacy-focused browser extension to export AI chats from ChatGPT, Cla
 > [!NOTE]
 > Please note that the developer does not test this extension with Chromium-based browsers, and it may or may not work.
 
-1. Download `ai-chat-exporter-chromium.zip` from the [releases page](https://github.com/Rat-S/ai-chat-exporter/releases)
+1. Download `ai-chat-exporter-chromium.zip` from the
+   [releases page](https://github.com/Rat-S/ai-chat-exporter/releases)
 2. Extract the zip file to a folder
 3. Open Chrome and navigate to `chrome://extensions/`
 4. Enable "Developer mode" (toggle in top-right corner)
@@ -37,7 +41,8 @@ Firefox users can install the extension directly from the [Firefox Add-ons store
 
 Alternatively, to install it manually/temporarily:
 
-1. Download `ai-chat-exporter-firefox.zip` from the [releases page](https://github.com/Rat-S/ai-chat-exporter/releases)
+1. Download `ai-chat-exporter-firefox.zip` from the
+   [releases page](https://github.com/Rat-S/ai-chat-exporter/releases)
 2. Open Firefox and navigate to `about:debugging`
 3. Click "This Firefox" → "Load Temporary Add-on..."
 4. Select the zip file
@@ -46,7 +51,7 @@ Alternatively, to install it manually/temporarily:
 
 1. Navigate to any supported AI chat platform
 2. Click the AI Chat Exporter icon in your browser toolbar
-3. Click "Export Chat" to download a Markdown file
+3. Choose Markdown or JSON, then click "Export Chat" to download the file
 4. The file is saved to your Downloads folder with a timestamped filename
 
 ## Development
@@ -81,6 +86,7 @@ Output files will be in `releases/` directory.
 │   ├── utils/           # Utility functions
 │   └── lib/             # Third-party libraries (Turndown.js)
 ├── popup/               # Extension popup UI
+├── schemas/             # JSON export schemas
 ├── docs/                # Documentation and privacy policy
 ├── manifest.json        # Extension manifest (v3)
 └── build.sh             # Build script
@@ -88,11 +94,13 @@ Output files will be in `releases/` directory.
 
 ## Privacy
 
-AI Chat Exporter does not collect, store, or transmit any personal data. See [PRIVACY.md](docs/privacy.html) for details.
+AI Chat Exporter does not collect, store, or transmit any personal data.
+See [PRIVACY.md](docs/privacy.html) for details.
 
 ## License
 
-This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. See [LICENSE](LICENSE) for the full license text.
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v. 2.0. See [LICENSE](LICENSE) for the full license text.
 
 ## Contributing
 

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ for TARGET in "${TARGETS[@]}"; do
     mkdir -p dist
 
     # Copy all files
-    cp -r background content docs/icons popup dist/
+    cp -r background content docs/icons popup schemas dist/
 
     # Parse/Modify manifest using Python for reliability
     python3 build.py "$TARGET"

--- a/content/formatters/json.js
+++ b/content/formatters/json.js
@@ -3,6 +3,14 @@ import { ExportFormatter } from './base.js';
 const SCHEMA_PATH = './schemas/export-v1.schema.json';
 
 export class JsonFormatter extends ExportFormatter {
+    /**
+     * Creates a JSON export formatter.
+     *
+     * @param {object} [options] Export defaults used when parser output is incomplete.
+     * @param {string} [options.platform] Fallback platform name for the `source` block.
+     * @param {string} [options.url] Fallback conversation URL for the `source` block.
+     * @param {string} [options.exportedAt] Fixed ISO timestamp, mainly for deterministic tests.
+     */
     constructor(options = {}) {
         super();
         this.platform = options.platform || null;
@@ -10,10 +18,30 @@ export class JsonFormatter extends ExportFormatter {
         this.exportedAt = options.exportedAt || null;
     }
 
+    /**
+     * Formats parser output as a pretty-printed schema v1 JSON export.
+     *
+     * @param {object} conversation Parsed conversation returned by a platform parser.
+     * @returns {string} JSON text suitable for download or clipboard export.
+     */
     format(conversation) {
         return JSON.stringify(this.toSchema(conversation), null, 2);
     }
 
+    /**
+     * Converts parser-specific conversation output into the stable export schema.
+     *
+     * Parser implementations do not all expose the same metadata fields, so this
+     * method normalizes the fields consumers need while preserving parser metadata
+     * under `metadata`.
+     *
+     * @param {object} conversation Parsed conversation returned by a platform parser.
+     * @param {string} [conversation.title] Conversation title.
+     * @param {string} [conversation.url] Conversation URL.
+     * @param {Array<{role?: string, content?: string}>} [conversation.messages] Messages to export.
+     * @param {Record<string, string|number|boolean|null>} [conversation.metadata] Parser metadata.
+     * @returns {object} Export object conforming to `schemas/export-v1.schema.json`.
+     */
     toSchema(conversation) {
         const metadata = conversation.metadata || {};
         const source = metadata.Source || this.platform || 'Unknown';
@@ -39,15 +67,31 @@ export class JsonFormatter extends ExportFormatter {
         };
     }
 
+    /**
+     * Returns the file extension used for JSON downloads.
+     *
+     * @returns {string} The `json` file extension.
+     */
     getFileExtension() {
         return 'json';
     }
 
+    /**
+     * Returns the MIME type used for JSON downloads.
+     *
+     * @returns {string} The JSON MIME type.
+     */
     getMimeType() {
         return 'application/json';
     }
 }
 
+/**
+ * Maps platform-specific role labels onto the schema's normalized role enum.
+ *
+ * @param {string} role Parser-provided role label.
+ * @returns {'user'|'assistant'|'system'|'tool'|'artifact'|'unknown'} Normalized schema role.
+ */
 function normalizeRole(role) {
     const normalized = String(role || '').toLowerCase();
 

--- a/content/formatters/json.js
+++ b/content/formatters/json.js
@@ -3,87 +3,87 @@ import { ExportFormatter } from './base.js';
 const SCHEMA_PATH = './schemas/export-v1.schema.json';
 
 export class JsonFormatter extends ExportFormatter {
-    /**
-     * Creates a JSON export formatter.
-     *
-     * @param {object} [options] Export defaults used when parser output is incomplete.
-     * @param {string} [options.platform] Fallback platform name for the `source` block.
-     * @param {string} [options.url] Fallback conversation URL for the `source` block.
-     * @param {string} [options.exportedAt] Fixed ISO timestamp, mainly for deterministic tests.
-     */
-    constructor(options = {}) {
-        super();
-        this.platform = options.platform || null;
-        this.url = options.url || null;
-        this.exportedAt = options.exportedAt || null;
-    }
+  /**
+   * Creates a JSON export formatter.
+   *
+   * @param {object} [options] Export defaults used when parser output is incomplete.
+   * @param {string} [options.platform] Fallback platform name for the `source` block.
+   * @param {string} [options.url] Fallback conversation URL for the `source` block.
+   * @param {string} [options.exportedAt] Fixed ISO timestamp, mainly for deterministic tests.
+   */
+  constructor(options = {}) {
+    super();
+    this.platform = options.platform || null;
+    this.url = options.url || null;
+    this.exportedAt = options.exportedAt || null;
+  }
 
-    /**
-     * Formats parser output as a pretty-printed schema v1 JSON export.
-     *
-     * @param {object} conversation Parsed conversation returned by a platform parser.
-     * @returns {string} JSON text suitable for download or clipboard export.
-     */
-    format(conversation) {
-        return JSON.stringify(this.toSchema(conversation), null, 2);
-    }
+  /**
+   * Formats parser output as a pretty-printed schema v1 JSON export.
+   *
+   * @param {object} conversation Parsed conversation returned by a platform parser.
+   * @returns {string} JSON text suitable for download or clipboard export.
+   */
+  format(conversation) {
+    return JSON.stringify(this.toSchema(conversation), null, 2);
+  }
 
-    /**
-     * Converts parser-specific conversation output into the stable export schema.
-     *
-     * Parser implementations do not all expose the same metadata fields, so this
-     * method normalizes the fields consumers need while preserving parser metadata
-     * under `metadata`.
-     *
-     * @param {object} conversation Parsed conversation returned by a platform parser.
-     * @param {string} [conversation.title] Conversation title.
-     * @param {string} [conversation.url] Conversation URL.
-     * @param {Array<{role?: string, content?: string}>} [conversation.messages] Messages to export.
-     * @param {Record<string, string|number|boolean|null>} [conversation.metadata] Parser metadata.
-     * @returns {object} Export object conforming to `schemas/export-v1.schema.json`.
-     */
-    toSchema(conversation) {
-        const metadata = conversation.metadata || {};
-        const source = metadata.Source || this.platform || 'Unknown';
+  /**
+   * Converts parser-specific conversation output into the stable export schema.
+   *
+   * Parser implementations do not all expose the same metadata fields, so this
+   * method normalizes the fields consumers need while preserving parser metadata
+   * under `metadata`.
+   *
+   * @param {object} conversation Parsed conversation returned by a platform parser.
+   * @param {string} [conversation.title] Conversation title.
+   * @param {string} [conversation.url] Conversation URL.
+   * @param {Array<{role?: string, content?: string}>} [conversation.messages] Messages to export.
+   * @param {Record<string, string|number|boolean|null>} [conversation.metadata] Parser metadata.
+   * @returns {object} Export object conforming to `schemas/export-v1.schema.json`.
+   */
+  toSchema(conversation) {
+    const metadata = conversation.metadata || {};
+    const source = metadata.Source || this.platform || 'Unknown';
 
+    return {
+      $schema: SCHEMA_PATH,
+      schemaVersion: 1,
+      exportedAt: this.exportedAt || new Date().toISOString(),
+      source: {
+        platform: source,
+        url: conversation.url || metadata.Link || this.url,
+        title: conversation.title || 'AI Chat Export',
+      },
+      messages: (conversation.messages || []).map((message, index) => {
         return {
-            '$schema': SCHEMA_PATH,
-            schemaVersion: 1,
-            exportedAt: this.exportedAt || new Date().toISOString(),
-            source: {
-                platform: source,
-                url: conversation.url || metadata.Link || this.url,
-                title: conversation.title || 'AI Chat Export'
-            },
-            messages: (conversation.messages || []).map((message, index) => {
-                return {
-                    index,
-                    role: normalizeRole(message.role),
-                    displayRole: message.role || 'Unknown',
-                    content: message.content || ''
-                };
-            }),
-            metadata
+          index,
+          role: normalizeRole(message.role),
+          displayRole: message.role || 'Unknown',
+          content: message.content || '',
         };
-    }
+      }),
+      metadata,
+    };
+  }
 
-    /**
-     * Returns the file extension used for JSON downloads.
-     *
-     * @returns {string} The `json` file extension.
-     */
-    getFileExtension() {
-        return 'json';
-    }
+  /**
+   * Returns the file extension used for JSON downloads.
+   *
+   * @returns {string} The `json` file extension.
+   */
+  getFileExtension() {
+    return 'json';
+  }
 
-    /**
-     * Returns the MIME type used for JSON downloads.
-     *
-     * @returns {string} The JSON MIME type.
-     */
-    getMimeType() {
-        return 'application/json';
-    }
+  /**
+   * Returns the MIME type used for JSON downloads.
+   *
+   * @returns {string} The JSON MIME type.
+   */
+  getMimeType() {
+    return 'application/json';
+  }
 }
 
 /**
@@ -93,37 +93,37 @@ export class JsonFormatter extends ExportFormatter {
  * @returns {'user'|'assistant'|'system'|'tool'|'artifact'|'unknown'} Normalized schema role.
  */
 function normalizeRole(role) {
-    const normalized = String(role || '').toLowerCase();
+  const normalized = String(role || '').toLowerCase();
 
-    if (normalized === 'user') {
-        return 'user';
-    }
+  if (normalized === 'user') {
+    return 'user';
+  }
 
-    if (normalized.includes('artifact')) {
-        return 'artifact';
-    }
+  if (normalized.includes('artifact')) {
+    return 'artifact';
+  }
 
-    if (normalized.includes('system')) {
-        return 'system';
-    }
+  if (normalized.includes('system')) {
+    return 'system';
+  }
 
-    if (normalized.includes('tool')) {
-        return 'tool';
-    }
+  if (normalized.includes('tool')) {
+    return 'tool';
+  }
 
-    if (
-        normalized.includes('assistant') ||
-        normalized.includes('chatgpt') ||
-        normalized.includes('claude') ||
-        normalized.includes('model') ||
-        normalized.includes('meta ai') ||
-        normalized.includes('mistral') ||
-        normalized.includes('deepseek') ||
-        normalized.includes('qwen') ||
-        normalized.includes('perplexity')
-    ) {
-        return 'assistant';
-    }
+  if (
+    normalized.includes('assistant') ||
+    normalized.includes('chatgpt') ||
+    normalized.includes('claude') ||
+    normalized.includes('model') ||
+    normalized.includes('meta ai') ||
+    normalized.includes('mistral') ||
+    normalized.includes('deepseek') ||
+    normalized.includes('qwen') ||
+    normalized.includes('perplexity')
+  ) {
+    return 'assistant';
+  }
 
-    return 'unknown';
+  return 'unknown';
 }

--- a/content/formatters/json.js
+++ b/content/formatters/json.js
@@ -1,0 +1,85 @@
+import { ExportFormatter } from './base.js';
+
+const SCHEMA_PATH = './schemas/export-v1.schema.json';
+
+export class JsonFormatter extends ExportFormatter {
+    constructor(options = {}) {
+        super();
+        this.platform = options.platform || null;
+        this.url = options.url || null;
+        this.exportedAt = options.exportedAt || null;
+    }
+
+    format(conversation) {
+        return JSON.stringify(this.toSchema(conversation), null, 2);
+    }
+
+    toSchema(conversation) {
+        const metadata = conversation.metadata || {};
+        const source = metadata.Source || this.platform || 'Unknown';
+
+        return {
+            '$schema': SCHEMA_PATH,
+            schemaVersion: 1,
+            exportedAt: this.exportedAt || new Date().toISOString(),
+            source: {
+                platform: source,
+                url: conversation.url || metadata.Link || this.url,
+                title: conversation.title || 'AI Chat Export'
+            },
+            messages: (conversation.messages || []).map((message, index) => {
+                return {
+                    index,
+                    role: normalizeRole(message.role),
+                    displayRole: message.role || 'Unknown',
+                    content: message.content || ''
+                };
+            }),
+            metadata
+        };
+    }
+
+    getFileExtension() {
+        return 'json';
+    }
+
+    getMimeType() {
+        return 'application/json';
+    }
+}
+
+function normalizeRole(role) {
+    const normalized = String(role || '').toLowerCase();
+
+    if (normalized === 'user') {
+        return 'user';
+    }
+
+    if (normalized.includes('artifact')) {
+        return 'artifact';
+    }
+
+    if (normalized.includes('system')) {
+        return 'system';
+    }
+
+    if (normalized.includes('tool')) {
+        return 'tool';
+    }
+
+    if (
+        normalized.includes('assistant') ||
+        normalized.includes('chatgpt') ||
+        normalized.includes('claude') ||
+        normalized.includes('model') ||
+        normalized.includes('meta ai') ||
+        normalized.includes('mistral') ||
+        normalized.includes('deepseek') ||
+        normalized.includes('qwen') ||
+        normalized.includes('perplexity')
+    ) {
+        return 'assistant';
+    }
+
+    return 'unknown';
+}

--- a/content/main.js
+++ b/content/main.js
@@ -10,6 +10,7 @@ import { MistralParser } from './parsers/mistral.js';
 import { GoogleSearchAIParser } from './parsers/google_search_ai.js';
 
 import { MarkdownFormatter } from './formatters/markdown.js';
+import { JsonFormatter } from './formatters/json.js';
 
 console.log('AI Chat Exporter script loaded');
 
@@ -29,6 +30,7 @@ const parsers = [
 // Registry of formatters
 const formatters = {
   markdown: new MarkdownFormatter(),
+  json: new JsonFormatter(),
 };
 
 let activeParser = null;

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "AI Chat Exporter",
   "version": "1.0.10",
-  "description": "Simple, private tool to export AI chats from ChatGPT, Claude, Gemini & more to Markdown.",
+  "description": "Export AI chats from ChatGPT, Claude, Gemini & more to Markdown or JSON.",
   "homepage_url": "https://ai-chat-export.covai.org/",
   "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": [
@@ -63,7 +63,8 @@
         "content/lib/*.js",
         "content/utils/*.js",
         "content/parsers/*.js",
-        "content/formatters/*.js"
+        "content/formatters/*.js",
+        "schemas/*.json"
       ],
       "matches": [
         "*://chatgpt.com/*",

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -20,7 +20,7 @@
         <div class="actions hidden" id="actions">
           <select id="format-select">
             <option value="markdown">Markdown (.md)</option>
-            <option value="json" disabled>JSON (Coming Soon)</option>
+            <option value="json">JSON (.json)</option>
             <option value="pdf" disabled>PDF (Coming Soon)</option>
           </select>
           <div class="button-group">

--- a/schemas/export-v1.schema.json
+++ b/schemas/export-v1.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/ChatExport",
+  "$defs": {
+    "NormalizedRole": {
+      "type": "string",
+      "enum": ["user", "assistant", "system", "tool", "artifact", "unknown"],
+      "description": "Normalized message role for cross-platform consumers."
+    },
+    "Source": {
+      "type": "object",
+      "properties": {
+        "platform": {
+          "type": "string",
+          "description": "Detected chat platform, such as ChatGPT, Claude, Gemini, or Mistral."
+        },
+        "url": {
+          "type": ["string", "null"],
+          "description": "Conversation URL at export time, if available."
+        },
+        "title": {
+          "type": "string",
+          "description": "Conversation title, with a fallback when unavailable."
+        }
+      },
+      "required": ["platform", "url", "title"],
+      "additionalProperties": false
+    },
+    "Message": {
+      "type": "object",
+      "properties": {
+        "index": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero-based message position in exported order."
+        },
+        "role": {
+          "$ref": "#/$defs/NormalizedRole"
+        },
+        "displayRole": {
+          "type": "string",
+          "description": "Original parser role label, such as User, ChatGPT, or Claude Artifact."
+        },
+        "content": {
+          "type": "string",
+          "description": "Message content as markdown-compatible text."
+        }
+      },
+      "required": ["index", "role", "displayRole", "content"],
+      "additionalProperties": false
+    },
+    "Metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean", "null"]
+      },
+      "description": "Platform-specific metadata preserved from parsers."
+    },
+    "ChatExport": {
+      "type": "object",
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "description": "Schema URL or relative schema path for this export."
+        },
+        "schemaVersion": {
+          "type": "integer",
+          "const": 1,
+          "description": "Chat export schema version."
+        },
+        "exportedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when the export was generated."
+        },
+        "source": {
+          "$ref": "#/$defs/Source"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Message"
+          },
+          "description": "Conversation messages in display order."
+        },
+        "metadata": {
+          "$ref": "#/$defs/Metadata"
+        }
+      },
+      "required": [
+        "$schema",
+        "schemaVersion",
+        "exportedAt",
+        "source",
+        "messages",
+        "metadata"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/export-v1.schema.json
+++ b/schemas/export-v1.schema.json
@@ -87,14 +87,7 @@
           "$ref": "#/$defs/Metadata"
         }
       },
-      "required": [
-        "$schema",
-        "schemaVersion",
-        "exportedAt",
-        "source",
-        "messages",
-        "metadata"
-      ],
+      "required": ["$schema", "schemaVersion", "exportedAt", "source", "messages", "metadata"],
       "additionalProperties": false
     }
   }

--- a/tests/json-formatter.test.mjs
+++ b/tests/json-formatter.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const schemaPath = path.resolve("schemas/export-v1.schema.json");
+
+async function importFormatter() {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-chat-exporter-"));
+  await fs.mkdir(path.join(tempDir, "content", "formatters"), {
+    recursive: true,
+  });
+  await fs.writeFile(path.join(tempDir, "package.json"), '{"type":"module"}');
+  await fs.copyFile(
+    path.resolve("content/formatters/base.js"),
+    path.join(tempDir, "content", "formatters", "base.js"),
+  );
+  await fs.copyFile(
+    path.resolve("content/formatters/json.js"),
+    path.join(tempDir, "content", "formatters", "json.js"),
+  );
+
+  return import(path.join(tempDir, "content", "formatters", "json.js"));
+}
+
+test("export v1 schema defines the chat export contract", async () => {
+  const schema = JSON.parse(await fs.readFile(schemaPath, "utf8"));
+
+  assert.equal(schema.$schema, "https://json-schema.org/draft/2020-12/schema");
+  assert.equal(schema.$ref, "#/$defs/ChatExport");
+  assert.equal(schema.$defs.ChatExport.additionalProperties, false);
+  assert.deepEqual(schema.$defs.ChatExport.required, [
+    "$schema",
+    "schemaVersion",
+    "exportedAt",
+    "source",
+    "messages",
+    "metadata",
+  ]);
+  assert.deepEqual(schema.$defs.NormalizedRole.enum, [
+    "user",
+    "assistant",
+    "system",
+    "tool",
+    "artifact",
+    "unknown",
+  ]);
+});
+test("JSON formatter emits normalized schema v1 exports", async () => {
+  const { JsonFormatter } = await importFormatter();
+  const formatter = new JsonFormatter({
+    platform: "ChatGPT",
+    url: "https://chatgpt.com/c/example",
+    exportedAt: "2026-05-20T00:00:00.000Z",
+  });
+
+  const output = JSON.parse(
+    formatter.format({
+      title: "Startup Runway Planning",
+      messages: [
+        { role: "User", content: "How much runway do we have?" },
+        { role: "ChatGPT", content: "About 8 months." },
+        { role: "Claude Artifact", content: "Artifact body" },
+      ],
+      metadata: {
+        Source: "ChatGPT",
+        Model: "GPT",
+      },
+    }),
+  );
+
+  assert.equal(output.$schema, "./schemas/export-v1.schema.json");
+  assert.equal(output.schemaVersion, 1);
+  assert.equal(output.exportedAt, "2026-05-20T00:00:00.000Z");
+  assert.deepEqual(output.source, {
+    platform: "ChatGPT",
+    url: "https://chatgpt.com/c/example",
+    title: "Startup Runway Planning",
+  });
+  assert.deepEqual(output.messages, [
+    {
+      index: 0,
+      role: "user",
+      displayRole: "User",
+      content: "How much runway do we have?",
+    },
+    {
+      index: 1,
+      role: "assistant",
+      displayRole: "ChatGPT",
+      content: "About 8 months.",
+    },
+    {
+      index: 2,
+      role: "artifact",
+      displayRole: "Claude Artifact",
+      content: "Artifact body",
+    },
+  ]);
+  assert.deepEqual(output.metadata, {
+    Source: "ChatGPT",
+    Model: "GPT",
+  });
+  assert.equal(formatter.getFileExtension(), "json");
+  assert.equal(formatter.getMimeType(), "application/json");
+});

--- a/tests/json-formatter.test.mjs
+++ b/tests/json-formatter.test.mjs
@@ -1,107 +1,107 @@
-import assert from "node:assert/strict";
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import test from "node:test";
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
 
-const schemaPath = path.resolve("schemas/export-v1.schema.json");
+const schemaPath = path.resolve('schemas/export-v1.schema.json');
 
 async function importFormatter() {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ai-chat-exporter-"));
-  await fs.mkdir(path.join(tempDir, "content", "formatters"), {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ai-chat-exporter-'));
+  await fs.mkdir(path.join(tempDir, 'content', 'formatters'), {
     recursive: true,
   });
-  await fs.writeFile(path.join(tempDir, "package.json"), '{"type":"module"}');
+  await fs.writeFile(path.join(tempDir, 'package.json'), '{"type":"module"}');
   await fs.copyFile(
-    path.resolve("content/formatters/base.js"),
-    path.join(tempDir, "content", "formatters", "base.js"),
+    path.resolve('content/formatters/base.js'),
+    path.join(tempDir, 'content', 'formatters', 'base.js'),
   );
   await fs.copyFile(
-    path.resolve("content/formatters/json.js"),
-    path.join(tempDir, "content", "formatters", "json.js"),
+    path.resolve('content/formatters/json.js'),
+    path.join(tempDir, 'content', 'formatters', 'json.js'),
   );
 
-  return import(path.join(tempDir, "content", "formatters", "json.js"));
+  return import(path.join(tempDir, 'content', 'formatters', 'json.js'));
 }
 
-test("export v1 schema defines the chat export contract", async () => {
-  const schema = JSON.parse(await fs.readFile(schemaPath, "utf8"));
+test('export v1 schema defines the chat export contract', async () => {
+  const schema = JSON.parse(await fs.readFile(schemaPath, 'utf8'));
 
-  assert.equal(schema.$schema, "https://json-schema.org/draft/2020-12/schema");
-  assert.equal(schema.$ref, "#/$defs/ChatExport");
+  assert.equal(schema.$schema, 'https://json-schema.org/draft/2020-12/schema');
+  assert.equal(schema.$ref, '#/$defs/ChatExport');
   assert.equal(schema.$defs.ChatExport.additionalProperties, false);
   assert.deepEqual(schema.$defs.ChatExport.required, [
-    "$schema",
-    "schemaVersion",
-    "exportedAt",
-    "source",
-    "messages",
-    "metadata",
+    '$schema',
+    'schemaVersion',
+    'exportedAt',
+    'source',
+    'messages',
+    'metadata',
   ]);
   assert.deepEqual(schema.$defs.NormalizedRole.enum, [
-    "user",
-    "assistant",
-    "system",
-    "tool",
-    "artifact",
-    "unknown",
+    'user',
+    'assistant',
+    'system',
+    'tool',
+    'artifact',
+    'unknown',
   ]);
 });
-test("JSON formatter emits normalized schema v1 exports", async () => {
+test('JSON formatter emits normalized schema v1 exports', async () => {
   const { JsonFormatter } = await importFormatter();
   const formatter = new JsonFormatter({
-    platform: "ChatGPT",
-    url: "https://chatgpt.com/c/example",
-    exportedAt: "2026-05-20T00:00:00.000Z",
+    platform: 'ChatGPT',
+    url: 'https://chatgpt.com/c/example',
+    exportedAt: '2026-05-20T00:00:00.000Z',
   });
 
   const output = JSON.parse(
     formatter.format({
-      title: "Startup Runway Planning",
+      title: 'Startup Runway Planning',
       messages: [
-        { role: "User", content: "How much runway do we have?" },
-        { role: "ChatGPT", content: "About 8 months." },
-        { role: "Claude Artifact", content: "Artifact body" },
+        { role: 'User', content: 'How much runway do we have?' },
+        { role: 'ChatGPT', content: 'About 8 months.' },
+        { role: 'Claude Artifact', content: 'Artifact body' },
       ],
       metadata: {
-        Source: "ChatGPT",
-        Model: "GPT",
+        Source: 'ChatGPT',
+        Model: 'GPT',
       },
     }),
   );
 
-  assert.equal(output.$schema, "./schemas/export-v1.schema.json");
+  assert.equal(output.$schema, './schemas/export-v1.schema.json');
   assert.equal(output.schemaVersion, 1);
-  assert.equal(output.exportedAt, "2026-05-20T00:00:00.000Z");
+  assert.equal(output.exportedAt, '2026-05-20T00:00:00.000Z');
   assert.deepEqual(output.source, {
-    platform: "ChatGPT",
-    url: "https://chatgpt.com/c/example",
-    title: "Startup Runway Planning",
+    platform: 'ChatGPT',
+    url: 'https://chatgpt.com/c/example',
+    title: 'Startup Runway Planning',
   });
   assert.deepEqual(output.messages, [
     {
       index: 0,
-      role: "user",
-      displayRole: "User",
-      content: "How much runway do we have?",
+      role: 'user',
+      displayRole: 'User',
+      content: 'How much runway do we have?',
     },
     {
       index: 1,
-      role: "assistant",
-      displayRole: "ChatGPT",
-      content: "About 8 months.",
+      role: 'assistant',
+      displayRole: 'ChatGPT',
+      content: 'About 8 months.',
     },
     {
       index: 2,
-      role: "artifact",
-      displayRole: "Claude Artifact",
-      content: "Artifact body",
+      role: 'artifact',
+      displayRole: 'Claude Artifact',
+      content: 'Artifact body',
     },
   ]);
   assert.deepEqual(output.metadata, {
-    Source: "ChatGPT",
-    Model: "GPT",
+    Source: 'ChatGPT',
+    Model: 'GPT',
   });
-  assert.equal(formatter.getFileExtension(), "json");
-  assert.equal(formatter.getMimeType(), "application/json");
+  assert.equal(formatter.getFileExtension(), 'json');
+  assert.equal(formatter.getMimeType(), 'application/json');
 });

--- a/tests/json-wiring.test.js
+++ b/tests/json-wiring.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const mainJs = fs.readFileSync('content/main.js', 'utf8');
+const popupHtml = fs.readFileSync('popup/popup.html', 'utf8');
+const manifestJson = fs.readFileSync('manifest.json', 'utf8');
+const buildSh = fs.readFileSync('build.sh', 'utf8');
+
+test('content script registers the JSON formatter', () => {
+  assert.match(mainJs, /import \{ JsonFormatter \} from '\.\/formatters\/json\.js';/);
+  assert.match(mainJs, /json: new JsonFormatter\(/);
+});
+
+test('popup enables JSON exports', () => {
+  assert.match(popupHtml, /<option value="json">JSON \(\.json\)<\/option>/);
+  assert.doesNotMatch(popupHtml, /<option value="json" disabled>/);
+});
+
+test('build includes the JSON schema files', () => {
+  assert.match(manifestJson, /"schemas\/\*\.json"/);
+  assert.match(buildSh, /cp -r background content docs\/icons popup schemas dist\//);
+});


### PR DESCRIPTION
## Summary
- add a v1 JSON Schema export contract
- add JsonFormatter to normalize parser output into the schema
- enable JSON in the popup and include schemas in packaged builds

## Notes
This is a start on issue #6 Phase 1: formalizing a structured export schema and adding JSON downloads. It does not attempt the later dual HTML/Markdown message blocks or AST roadmap items.

## Test plan
- npm test
- node --check content/formatters/json.js
- ./build.sh chromium