### PR TITLE
feat: export all web pages, multi-theme selector & expanded permissions

### DIFF
--- a/content/formatters/doc.js
+++ b/content/formatters/doc.js
@@ -26,19 +26,38 @@ export class DocFormatter extends ExportFormatter {
       metaParts.push(`Method: ${escapeHtml(method)}`);
     }
 
-    const formattedMessages = messages
-      .map((msg) => {
-        const isUser = msg.role === 'User';
-        const roleClass = isUser ? 'role-user' : 'role-assistant';
-        const roleName = isUser ? 'User' : platform;
-        const avatarText = isUser ? 'U' : platform[0];
-        const rawHtmlContent = markdownToHtml(msg.content);
-        // Strip copy buttons and inline SVGs which cause LibreOffice HTML import filter errors
-        const htmlContent = rawHtmlContent
-          .replace(/<button[^>]*>[\s\S]*?<\/button>/gi, '')
-          .replace(/<svg[^>]*>[\s\S]*?<\/svg>/gi, '');
+    const isWebArticle = platform === 'Web Article' || platform === 'WebArticle';
 
-        return `
+    const formattedMessages = isWebArticle
+      ? messages
+          .map((msg) => {
+            const rawHtmlContent = markdownToHtml(msg.content);
+            const htmlContent = rawHtmlContent
+              .replace(/<button[^>]*>[\s\S]*?<\/button>/gi, '')
+              .replace(/<svg[^>]*>[\s\S]*?<\/svg>/gi, '');
+
+            return `
+        <div class="message-card role-assistant">
+          <div class="message-content">
+            ${htmlContent}
+          </div>
+        </div>
+      `;
+          })
+          .join('\n')
+      : messages
+          .map((msg) => {
+            const isUser = msg.role === 'User';
+            const roleClass = isUser ? 'role-user' : 'role-assistant';
+            const roleName = isUser ? 'User' : msg.role && msg.role !== 'Assistant' ? msg.role : platform;
+            const avatarText = isUser ? 'U' : (roleName[0] || 'A');
+            const rawHtmlContent = markdownToHtml(msg.content);
+            // Strip copy buttons and inline SVGs which cause LibreOffice HTML import filter errors
+            const htmlContent = rawHtmlContent
+              .replace(/<button[^>]*>[\s\S]*?<\/button>/gi, '')
+              .replace(/<svg[^>]*>[\s\S]*?<\/svg>/gi, '');
+
+            return `
         <div class="message-card ${roleClass}">
           <div class="message-header">
             <span class="message-avatar">${avatarText}</span>
@@ -49,8 +68,8 @@ export class DocFormatter extends ExportFormatter {
           </div>
         </div>
       `;
-      })
-      .join('\n');
+          })
+          .join('\n');
 
     return `<html xmlns:o='urn:schemas-microsoft-com:office:office' xmlns:w='urn:schemas-microsoft-com:office:word' xmlns='http://www.w3.org/TR/REC-html40'>
 <head>

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -857,6 +857,9 @@ ${prismJs}
         border-top: none !important;
         color: #64748b !important;
       }
+      .theme-switch-wrapper {
+        display: none !important;
+      }
       * {
         -webkit-print-color-adjust: exact !important;
         print-color-adjust: exact !important;
@@ -880,11 +883,17 @@ ${prismJs}
         <h1>${escapeHtml(title || 'AI Chat Export')}</h1>
       </div>
       <div class="theme-switch-wrapper">
-        <span style="font-size: 0.85rem; color: var(--text-secondary);">Dark Theme</span>
-        <label class="theme-switch" for="theme-toggle-checkbox">
-          <input type="checkbox" id="theme-toggle-checkbox" />
-          <div class="slider"></div>
-        </label>
+        <label for="theme-select-dropdown" style="font-size: 0.85rem; color: var(--text-secondary); font-weight: 500; margin-right: 6px;">Theme:</label>
+        <select id="theme-select-dropdown" style="background: var(--bg-card); color: var(--text-primary); border: 1px solid var(--border); border-radius: 6px; padding: 4px 8px; font-size: 0.85rem; outline: none; cursor: pointer;">
+          <option value="modern-light">Modern Light</option>
+          <option value="modern-dark">Modern Dark</option>
+          <option value="github-light">GitHub Light</option>
+          <option value="github-dark">GitHub Dark</option>
+          <option value="nord">Nord Slate</option>
+          <option value="dracula">Dracula</option>
+          <option value="solarized-light">Solarized Light</option>
+          <option value="solarized-dark">Solarized Dark</option>
+        </select>
       </div>
     </header>
 
@@ -898,7 +907,7 @@ ${prismJs}
   </div>
 
   <script>
-    const toggle = document.getElementById('theme-toggle-checkbox');
+    const themeDropdown = document.getElementById('theme-select-dropdown');
     let storedTheme = null;
     try {
       storedTheme = localStorage.getItem('theme');
@@ -907,43 +916,34 @@ ${prismJs}
     }
     
     if (!storedTheme) {
-      storedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      const docTheme = document.documentElement.getAttribute('data-theme');
+      if (docTheme && docTheme !== 'system') {
+        storedTheme = docTheme;
+      } else {
+        storedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'modern-dark' : 'modern-light';
+      }
     }
     
     function applyDocumentTheme(theme) {
-      if (theme === 'dark' || theme === 'modern-dark') {
-        document.documentElement.setAttribute('data-theme', 'dark');
-        if (toggle) toggle.checked = true;
-      } else if (theme === 'light' || theme === 'modern-light') {
-        document.documentElement.removeAttribute('data-theme');
-        if (toggle) toggle.checked = false;
-      } else {
-        const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (isSystemDark) {
-          document.documentElement.setAttribute('data-theme', 'dark');
-          if (toggle) toggle.checked = true;
-        } else {
-          document.documentElement.removeAttribute('data-theme');
-          if (toggle) toggle.checked = false;
-        }
+      let resolvedTheme = theme;
+      if (theme === 'dark') resolvedTheme = 'modern-dark';
+      if (theme === 'light') resolvedTheme = 'modern-light';
+
+      document.documentElement.setAttribute('data-theme', resolvedTheme);
+      if (themeDropdown) {
+        themeDropdown.value = resolvedTheme;
       }
     }
 
     applyDocumentTheme(storedTheme);
     
-    if (toggle) {
-      toggle.addEventListener('change', (e) => {
-        if (e.target.checked) {
-          document.documentElement.setAttribute('data-theme', 'dark');
-          try {
-            localStorage.setItem('theme', 'dark');
-          } catch (err) {}
-        } else {
-          document.documentElement.removeAttribute('data-theme');
-          try {
-            localStorage.setItem('theme', 'light');
-          } catch (err) {}
-        }
+    if (themeDropdown) {
+      themeDropdown.addEventListener('change', (e) => {
+        const selectedTheme = e.target.value;
+        applyDocumentTheme(selectedTheme);
+        try {
+          localStorage.setItem('theme', selectedTheme);
+        } catch (err) {}
       });
     }
 

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -17,13 +17,39 @@ export class HtmlFormatter extends ExportFormatter {
 
     const isWebArticle = platform === 'Web Article' || platform === 'WebArticle';
 
+    // Table of Contents
+    let tocHtml = '';
+    if (options?.includeToc && messages && messages.length > 0) {
+      const tocItems = messages
+        .map((m, i) => {
+          const isUser = m.role === 'User';
+          const label = isUser ? 'User' : m.role && m.role !== 'Assistant' ? m.role : platform;
+          const snippet = (m.content || '')
+            .replace(/<[^>]*>/g, '')
+            .replace(/\[(?:x|X|\s)\]/g, '')
+            .replace(/[`#*_~]/g, '')
+            .trim()
+            .substring(0, 60);
+          return `<li><a href="#msg-card-${i}"><strong>${escapeHtml(label)}:</strong> ${escapeHtml(snippet || 'Message')}</a></li>`;
+        })
+        .join('\n');
+      tocHtml = `
+        <nav class="toc-card" aria-label="Table of Contents">
+          <div class="toc-title">📑 Table of Contents</div>
+          <ol class="toc-list">
+            ${tocItems}
+          </ol>
+        </nav>
+      `;
+    }
+
     // Convert messages
     const formattedMessages = isWebArticle
       ? messages
-          .map((msg) => {
+          .map((msg, idx) => {
             const htmlContent = sanitizeHtml(markdownToHtml(msg.content));
             return `
-        <article class="article-card">
+        <article id="msg-card-${idx}" class="article-card">
           <div class="message-content">
             ${htmlContent}
           </div>
@@ -32,7 +58,7 @@ export class HtmlFormatter extends ExportFormatter {
           })
           .join('\n')
       : messages
-          .map((msg) => {
+          .map((msg, idx) => {
             const isUser = msg.role === 'User';
             const roleClass = isUser ? 'role-user' : 'role-assistant';
             const roleName = isUser ? 'User' : msg.role && msg.role !== 'Assistant' ? msg.role : platform;
@@ -40,7 +66,7 @@ export class HtmlFormatter extends ExportFormatter {
             const htmlContent = sanitizeHtml(markdownToHtml(msg.content));
 
             return `
-        <div class="message-card ${roleClass}">
+        <div id="msg-card-${idx}" class="message-card ${roleClass}">
           <div class="message-header">
             <div class="message-header-info">
               <div class="message-avatar">${avatarText}</div>
@@ -347,6 +373,50 @@ ${prismJs}
 
     input:checked + .slider:before {
       transform: translateX(24px);
+    }
+
+    .toc-card {
+      background-color: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.1rem 1.35rem;
+      margin-bottom: 0.5rem;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+    }
+
+    .toc-title {
+      font-size: 0.95rem;
+      font-weight: 700;
+      color: var(--text-primary);
+      margin-bottom: 0.6rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .toc-list {
+      margin: 0;
+      padding-left: 1.25rem;
+      list-style-type: decimal;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .toc-list li {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      line-height: 1.45;
+    }
+
+    .toc-list a {
+      color: var(--accent);
+      text-decoration: none;
+      transition: color 0.15s ease;
+    }
+
+    .toc-list a:hover {
+      text-decoration: underline;
     }
 
     .message-list {
@@ -828,6 +898,7 @@ ${prismJs}
     </header>
 
     <main class="message-list">
+      ${tocHtml}
       ${formattedMessages}
     </main>
 

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -13,21 +13,36 @@ export class HtmlFormatter extends ExportFormatter {
     const model = conversation.metadata?.Model || '';
     const method = conversation.metadata?.Method || '';
 
-    // Convert messages
-    const formattedMessages = messages
-      .map((msg) => {
-        const isUser = msg.role === 'User';
-        const roleClass = isUser ? 'role-user' : 'role-assistant';
-        const roleName = isUser ? 'User' : platform;
-        const avatarText = isUser ? 'U' : platform[0];
-        const htmlContent = sanitizeHtml(markdownToHtml(msg.content));
+    const isWebArticle = platform === 'Web Article' || platform === 'WebArticle';
 
-        return `
+    // Convert messages
+    const formattedMessages = isWebArticle
+      ? messages
+          .map((msg) => {
+            const htmlContent = sanitizeHtml(markdownToHtml(msg.content));
+            return `
+        <article class="article-card">
+          <div class="message-content">
+            ${htmlContent}
+          </div>
+        </article>
+      `;
+          })
+          .join('\n')
+      : messages
+          .map((msg) => {
+            const isUser = msg.role === 'User';
+            const roleClass = isUser ? 'role-user' : 'role-assistant';
+            const roleName = isUser ? 'User' : msg.role && msg.role !== 'Assistant' ? msg.role : platform;
+            const avatarText = isUser ? 'U' : (roleName[0] || 'A');
+            const htmlContent = sanitizeHtml(markdownToHtml(msg.content));
+
+            return `
         <div class="message-card ${roleClass}">
           <div class="message-header">
             <div class="message-header-info">
               <div class="message-avatar">${avatarText}</div>
-              <span>${roleName}</span>
+              <span>${escapeHtml(roleName)}</span>
             </div>
             <button class="copy-msg-btn" title="Copy message text">
               <svg class="copy-icon" viewBox="0 0 24 24" width="13" height="13"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
@@ -39,8 +54,8 @@ export class HtmlFormatter extends ExportFormatter {
           </div>
         </div>
       `;
-      })
-      .join('\n');
+          })
+          .join('\n');
 
     const katexHeaders = `
   <style>
@@ -87,7 +102,7 @@ ${prismJs}
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@600;700&family=Fira+Code:wght@400;500&display=swap');
 
-    :root {
+    :root, [data-theme="modern-light"] {
       --bg-app: #f8fafc;
       --bg-card: #ffffff;
       --bg-bubble-user: #e2e8f0;
@@ -103,7 +118,7 @@ ${prismJs}
       --scrollbar-thumb: #cbd5e1;
     }
 
-    [data-theme="dark"] {
+    [data-theme="modern-dark"], [data-theme="dark"] {
       --bg-app: #0f172a;
       --bg-card: #1e293b;
       --bg-bubble-user: #334155;
@@ -117,6 +132,102 @@ ${prismJs}
       --code-text: #f8fafc;
       --code-header-bg: #0f172a;
       --scrollbar-thumb: #475569;
+    }
+
+    [data-theme="github-light"] {
+      --bg-app: #ffffff;
+      --bg-card: #ffffff;
+      --bg-bubble-user: #f6f8fa;
+      --bg-bubble-ai: #ffffff;
+      --text-primary: #1f2328;
+      --text-secondary: #656d76;
+      --accent: #0969da;
+      --accent-light: #ddf4ff;
+      --border: #d0d7de;
+      --code-bg: #f6f8fa;
+      --code-text: #1f2328;
+      --code-header-bg: #eaeef2;
+      --scrollbar-thumb: #d0d7de;
+    }
+
+    [data-theme="github-dark"] {
+      --bg-app: #0d1117;
+      --bg-card: #161b22;
+      --bg-bubble-user: #21262d;
+      --bg-bubble-ai: #161b22;
+      --text-primary: #e6edf3;
+      --text-secondary: #8d96a0;
+      --accent: #2f81f7;
+      --accent-light: #101d2e;
+      --border: #30363d;
+      --code-bg: #161b22;
+      --code-text: #e6edf3;
+      --code-header-bg: #21262d;
+      --scrollbar-thumb: #30363d;
+    }
+
+    [data-theme="nord"] {
+      --bg-app: #2e3440;
+      --bg-card: #3b4252;
+      --bg-bubble-user: #434c5e;
+      --bg-bubble-ai: #3b4252;
+      --text-primary: #eceff4;
+      --text-secondary: #d8dee9;
+      --accent: #88c0d0;
+      --accent-light: #3b4252;
+      --border: #4c566a;
+      --code-bg: #242933;
+      --code-text: #eceff4;
+      --code-header-bg: #2e3440;
+      --scrollbar-thumb: #4c566a;
+    }
+
+    [data-theme="dracula"] {
+      --bg-app: #282a36;
+      --bg-card: #343746;
+      --bg-bubble-user: #44475a;
+      --bg-bubble-ai: #343746;
+      --text-primary: #f8f8f2;
+      --text-secondary: #6272a4;
+      --accent: #bd93f9;
+      --accent-light: #3b2d54;
+      --border: #44475a;
+      --code-bg: #1e1f29;
+      --code-text: #f8f8f2;
+      --code-header-bg: #282a36;
+      --scrollbar-thumb: #6272a4;
+    }
+
+    [data-theme="solarized-light"] {
+      --bg-app: #fdf6e3;
+      --bg-card: #eee8d5;
+      --bg-bubble-user: #eee8d5;
+      --bg-bubble-ai: #fdf6e3;
+      --text-primary: #657b83;
+      --text-secondary: #93a1a1;
+      --accent: #268bd2;
+      --accent-light: #e0f2fe;
+      --border: #d3cbb7;
+      --code-bg: #073642;
+      --code-text: #839496;
+      --code-header-bg: #002b36;
+      --scrollbar-thumb: #93a1a1;
+    }
+
+    [data-theme="solarized-dark"] {
+      --bg-app: #002b36;
+      --bg-card: #073642;
+      --bg-bubble-user: #073642;
+      --bg-bubble-ai: #002b36;
+      --text-primary: #839496;
+      --text-secondary: #586e75;
+      --accent: #2ab7ca;
+      --accent-light: #0d3b46;
+      --border: #095264;
+      --code-bg: #073642;
+      --code-text: #93a1a1;
+      --code-header-bg: #002b36;
+      --scrollbar-thumb: #586e75;
     }
 
     html, body {
@@ -767,11 +878,17 @@ ${prismJs}
         <h1>${escapeHtml(title || 'AI Chat Export')}</h1>
       </div>
       <div class="theme-switch-wrapper">
-        <span style="font-size: 0.85rem; color: var(--text-secondary);">Dark Theme</span>
-        <label class="theme-switch" for="theme-toggle-checkbox">
-          <input type="checkbox" id="theme-toggle-checkbox" />
-          <div class="slider"></div>
-        </label>
+        <label for="theme-select-dropdown" style="font-size: 0.85rem; color: var(--text-secondary); font-weight: 500;">Theme:</label>
+        <select id="theme-select-dropdown" style="background: var(--bg-card); color: var(--text-primary); border: 1px solid var(--border); border-radius: 6px; padding: 4px 8px; font-size: 0.85rem; outline: none; cursor: pointer;">
+          <option value="modern-light">Modern Light</option>
+          <option value="modern-dark">Modern Dark</option>
+          <option value="github-light">GitHub Light</option>
+          <option value="github-dark">GitHub Dark</option>
+          <option value="nord">Nord Slate</option>
+          <option value="dracula">Dracula</option>
+          <option value="solarized-light">Solarized Light</option>
+          <option value="solarized-dark">Solarized Dark</option>
+        </select>
       </div>
     </header>
 
@@ -785,7 +902,7 @@ ${prismJs}
   </div>
 
   <script>
-    const toggle = document.getElementById('theme-toggle-checkbox');
+    const themeDropdown = document.getElementById('theme-select-dropdown');
     let storedTheme = null;
     try {
       storedTheme = localStorage.getItem('theme');
@@ -794,43 +911,29 @@ ${prismJs}
     }
     
     if (!storedTheme) {
-      storedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      storedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'modern-dark' : 'modern-light';
     }
     
     function applyDocumentTheme(theme) {
-      if (theme === 'dark') {
-        document.documentElement.setAttribute('data-theme', 'dark');
-        if (toggle) toggle.checked = true;
-      } else if (theme === 'light') {
-        document.documentElement.removeAttribute('data-theme');
-        if (toggle) toggle.checked = false;
-      } else {
-        const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (isSystemDark) {
-          document.documentElement.setAttribute('data-theme', 'dark');
-          if (toggle) toggle.checked = true;
-        } else {
-          document.documentElement.removeAttribute('data-theme');
-          if (toggle) toggle.checked = false;
-        }
+      let resolvedTheme = theme;
+      if (theme === 'dark') resolvedTheme = 'modern-dark';
+      if (theme === 'light') resolvedTheme = 'modern-light';
+
+      document.documentElement.setAttribute('data-theme', resolvedTheme);
+      if (themeDropdown) {
+        themeDropdown.value = resolvedTheme;
       }
     }
 
     applyDocumentTheme(storedTheme);
     
-    if (toggle) {
-      toggle.addEventListener('change', (e) => {
-        if (e.target.checked) {
-          document.documentElement.setAttribute('data-theme', 'dark');
-          try {
-            localStorage.setItem('theme', 'dark');
-          } catch (err) {}
-        } else {
-          document.documentElement.removeAttribute('data-theme');
-          try {
-            localStorage.setItem('theme', 'light');
-          } catch (err) {}
-        }
+    if (themeDropdown) {
+      themeDropdown.addEventListener('change', (e) => {
+        const selectedTheme = e.target.value;
+        applyDocumentTheme(selectedTheme);
+        try {
+          localStorage.setItem('theme', selectedTheme);
+        } catch (err) {}
       });
     }
 

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -878,17 +878,11 @@ ${prismJs}
         <h1>${escapeHtml(title || 'AI Chat Export')}</h1>
       </div>
       <div class="theme-switch-wrapper">
-        <label for="theme-select-dropdown" style="font-size: 0.85rem; color: var(--text-secondary); font-weight: 500;">Theme:</label>
-        <select id="theme-select-dropdown" style="background: var(--bg-card); color: var(--text-primary); border: 1px solid var(--border); border-radius: 6px; padding: 4px 8px; font-size: 0.85rem; outline: none; cursor: pointer;">
-          <option value="modern-light">Modern Light</option>
-          <option value="modern-dark">Modern Dark</option>
-          <option value="github-light">GitHub Light</option>
-          <option value="github-dark">GitHub Dark</option>
-          <option value="nord">Nord Slate</option>
-          <option value="dracula">Dracula</option>
-          <option value="solarized-light">Solarized Light</option>
-          <option value="solarized-dark">Solarized Dark</option>
-        </select>
+        <span style="font-size: 0.85rem; color: var(--text-secondary);">Dark Theme</span>
+        <label class="theme-switch" for="theme-toggle-checkbox">
+          <input type="checkbox" id="theme-toggle-checkbox" />
+          <div class="slider"></div>
+        </label>
       </div>
     </header>
 
@@ -902,7 +896,7 @@ ${prismJs}
   </div>
 
   <script>
-    const themeDropdown = document.getElementById('theme-select-dropdown');
+    const toggle = document.getElementById('theme-toggle-checkbox');
     let storedTheme = null;
     try {
       storedTheme = localStorage.getItem('theme');
@@ -911,29 +905,43 @@ ${prismJs}
     }
     
     if (!storedTheme) {
-      storedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'modern-dark' : 'modern-light';
+      storedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
     
     function applyDocumentTheme(theme) {
-      let resolvedTheme = theme;
-      if (theme === 'dark') resolvedTheme = 'modern-dark';
-      if (theme === 'light') resolvedTheme = 'modern-light';
-
-      document.documentElement.setAttribute('data-theme', resolvedTheme);
-      if (themeDropdown) {
-        themeDropdown.value = resolvedTheme;
+      if (theme === 'dark' || theme === 'modern-dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        if (toggle) toggle.checked = true;
+      } else if (theme === 'light' || theme === 'modern-light') {
+        document.documentElement.removeAttribute('data-theme');
+        if (toggle) toggle.checked = false;
+      } else {
+        const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (isSystemDark) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+          if (toggle) toggle.checked = true;
+        } else {
+          document.documentElement.removeAttribute('data-theme');
+          if (toggle) toggle.checked = false;
+        }
       }
     }
 
     applyDocumentTheme(storedTheme);
     
-    if (themeDropdown) {
-      themeDropdown.addEventListener('change', (e) => {
-        const selectedTheme = e.target.value;
-        applyDocumentTheme(selectedTheme);
-        try {
-          localStorage.setItem('theme', selectedTheme);
-        } catch (err) {}
+    if (toggle) {
+      toggle.addEventListener('change', (e) => {
+        if (e.target.checked) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+          try {
+            localStorage.setItem('theme', 'dark');
+          } catch (err) {}
+        } else {
+          document.documentElement.removeAttribute('data-theme');
+          try {
+            localStorage.setItem('theme', 'light');
+          } catch (err) {}
+        }
       });
     }
 

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -3,7 +3,7 @@ import { sanitizeHtml } from '../utils/sanitizer.js';
 import { katexCss, katexJs, autoRenderJs, prismCss, prismJs } from '../lib/assets.js';
 
 export class HtmlFormatter extends ExportFormatter {
-  format(conversation) {
+  format(conversation, options = {}) {
     const { title, messages } = conversation;
     const now = new Date();
     const formattedDate = `${now.getMonth() + 1}/${now.getDate()}/${now.getFullYear()} ${now.toLocaleTimeString('en-US', { hour12: false })}`;
@@ -12,6 +12,8 @@ export class HtmlFormatter extends ExportFormatter {
     const link = conversation.url || conversation.metadata?.Link || '';
     const model = conversation.metadata?.Model || '';
     const method = conversation.metadata?.Method || '';
+    const selectedTheme = options?.theme || conversation?.theme || '';
+    const themeAttr = selectedTheme && selectedTheme !== 'system' ? ` data-theme="${escapeHtml(selectedTheme)}"` : '';
 
     const isWebArticle = platform === 'Web Article' || platform === 'WebArticle';
 
@@ -94,7 +96,7 @@ ${prismJs}
     `;
 
     return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en"${themeAttr}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -717,25 +717,28 @@ ${prismJs}
           margin: 0 !important;
           padding: 12mm 15mm !important;
           box-sizing: border-box !important;
-        }
-        html[data-theme='dark'], html[data-theme='dark'] body {
-          background-color: #0f172a !important;
-          color: #f8fafc !important;
-          width: 100% !important;
-          margin: 0 !important;
-          padding: 12mm 15mm !important;
-          box-sizing: border-box !important;
-        }
-      .theme-switch-wrapper,
-      .copy-code-btn,
-      .copy-msg-btn {
-        display: none !important;
+    @media print {
+      @page {
+        margin: 12mm 15mm;
+        size: auto;
+      }
+      body {
+        background-color: var(--bg-app) !important;
+        color: var(--text-primary) !important;
+        width: 100% !important;
+        margin: 0 !important;
+        padding: 0 !important;
       }
       .container {
         padding: 0 !important;
         max-width: 100% !important;
         width: 100% !important;
         box-sizing: border-box !important;
+      }
+      .copy-code-btn,
+      .copy-msg-btn,
+      .theme-switch-wrapper {
+        display: none !important;
       }
       .message-card {
         max-width: 100% !important;
@@ -744,61 +747,37 @@ ${prismJs}
         page-break-inside: auto;
         break-inside: auto;
         box-shadow: none !important;
-        border: 1px solid #cbd5e1 !important;
+        border: 1px solid var(--border) !important;
       }
-      html[data-theme='dark'] .message-card {
-        border-color: #334155 !important;
+      .message-card.role-user {
+        background-color: var(--bg-bubble-user) !important;
+        color: var(--text-primary) !important;
       }
-      html:not([data-theme='dark']) .message-card.role-user {
-        align-self: stretch !important;
-        max-width: 100% !important;
-        background-color: #f1f5f9 !important;
-        color: #0f172a !important;
+      .message-card.role-assistant {
+        background-color: var(--bg-bubble-ai) !important;
+        color: var(--text-primary) !important;
       }
-      html[data-theme='dark'] .message-card.role-user {
-        align-self: stretch !important;
-        max-width: 100% !important;
-        background-color: #1e293b !important;
-        color: #f8fafc !important;
-      }
-      html:not([data-theme='dark']) .message-card.role-assistant {
-        align-self: stretch !important;
-        max-width: 100% !important;
-        background-color: #ffffff !important;
-        color: #0f172a !important;
-      }
-      html[data-theme='dark'] .message-card.role-assistant {
-        align-self: stretch !important;
-        max-width: 100% !important;
-        background-color: #0f172a !important;
-        color: #f8fafc !important;
+      .article-card {
+        background-color: var(--bg-card) !important;
+        border: 1px solid var(--border) !important;
+        color: var(--text-primary) !important;
       }
       .message-header,
       h1, h2, h3, h4, h5, h6 {
         page-break-after: avoid;
         break-after: avoid;
-      }
-      html:not([data-theme='dark']) .message-header,
-      html:not([data-theme='dark']) h1, html:not([data-theme='dark']) h2, html:not([data-theme='dark']) h3, html:not([data-theme='dark']) h4, html:not([data-theme='dark']) h5, html:not([data-theme='dark']) h6 {
-        color: #0f172a !important;
-      }
-      html[data-theme='dark'] .message-header,
-      html[data-theme='dark'] h1, html[data-theme='dark'] h2, html[data-theme='dark'] h3, html[data-theme='dark'] h4, html[data-theme='dark'] h5, html[data-theme='dark'] h6 {
-        color: #f8fafc !important;
-      }
-      .message-header {
-        color: #475569 !important;
+        color: var(--text-primary) !important;
       }
       .thinking-block {
-        background-color: rgba(79, 70, 229, 0.04) !important;
-        border-color: #e2e8f0 !important;
+        background-color: rgba(99, 102, 241, 0.08) !important;
+        border-color: var(--border) !important;
       }
       .thinking-summary {
-        color: #4f46e5 !important;
+        color: var(--accent) !important;
       }
       .thinking-content {
-        color: #475569 !important;
-        border-top-color: #e2e8f0 !important;
+        color: var(--text-secondary) !important;
+        border-top-color: var(--border) !important;
         display: block !important;
       }
       details.thinking-block .thinking-content {
@@ -809,14 +788,14 @@ ${prismJs}
         box-sizing: border-box !important;
         page-break-inside: avoid;
         break-inside: avoid;
-        background-color: #0f172a !important;
-        color: #f8fafc !important;
-        border-color: #1e293b !important;
+        background-color: var(--code-bg) !important;
+        color: var(--code-text) !important;
+        border-color: var(--border) !important;
       }
       .code-card-header {
-        background-color: #1e293b !important;
-        color: #94a3b8 !important;
-        border-bottom-color: #334155 !important;
+        background-color: var(--code-header-bg) !important;
+        color: var(--text-secondary) !important;
+        border-bottom-color: var(--border) !important;
       }
       pre, code {
         white-space: pre-wrap !important;
@@ -840,11 +819,11 @@ ${prismJs}
       }
       th, td {
         word-break: break-word !important;
-        border-color: #cbd5e1 !important;
+        border-color: var(--border) !important;
       }
       th {
-        background-color: #f1f5f9 !important;
-        color: #0f172a !important;
+        background-color: var(--bg-bubble-user) !important;
+        color: var(--text-primary) !important;
       }
       img {
         max-width: 100% !important;
@@ -855,10 +834,7 @@ ${prismJs}
       .export-footer {
         margin-top: 1.5rem !important;
         border-top: none !important;
-        color: #64748b !important;
-      }
-      .theme-switch-wrapper {
-        display: none !important;
+        color: var(--text-secondary) !important;
       }
       * {
         -webkit-print-color-adjust: exact !important;
@@ -882,19 +858,6 @@ ${prismJs}
         </div>
         <h1>${escapeHtml(title || 'AI Chat Export')}</h1>
       </div>
-      <div class="theme-switch-wrapper">
-        <label for="theme-select-dropdown" style="font-size: 0.85rem; color: var(--text-secondary); font-weight: 500; margin-right: 6px;">Theme:</label>
-        <select id="theme-select-dropdown" style="background: var(--bg-card); color: var(--text-primary); border: 1px solid var(--border); border-radius: 6px; padding: 4px 8px; font-size: 0.85rem; outline: none; cursor: pointer;">
-          <option value="modern-light">Modern Light</option>
-          <option value="modern-dark">Modern Dark</option>
-          <option value="github-light">GitHub Light</option>
-          <option value="github-dark">GitHub Dark</option>
-          <option value="nord">Nord Slate</option>
-          <option value="dracula">Dracula</option>
-          <option value="solarized-light">Solarized Light</option>
-          <option value="solarized-dark">Solarized Dark</option>
-        </select>
-      </div>
     </header>
 
     <main class="message-list">
@@ -907,44 +870,13 @@ ${prismJs}
   </div>
 
   <script>
-    const themeDropdown = document.getElementById('theme-select-dropdown');
-    let storedTheme = null;
-    try {
-      storedTheme = localStorage.getItem('theme');
-    } catch (e) {
-      console.warn('localStorage is not available:', e);
-    }
-    
-    if (!storedTheme) {
-      const docTheme = document.documentElement.getAttribute('data-theme');
-      if (docTheme && docTheme !== 'system') {
-        storedTheme = docTheme;
-      } else {
-        storedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'modern-dark' : 'modern-light';
-      }
-    }
-    
     function applyDocumentTheme(theme) {
-      let resolvedTheme = theme;
-      if (theme === 'dark') resolvedTheme = 'modern-dark';
-      if (theme === 'light') resolvedTheme = 'modern-light';
-
-      document.documentElement.setAttribute('data-theme', resolvedTheme);
-      if (themeDropdown) {
-        themeDropdown.value = resolvedTheme;
+      if (theme && theme !== 'system') {
+        document.documentElement.setAttribute('data-theme', theme);
+      } else {
+        const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.setAttribute('data-theme', isDark ? 'modern-dark' : 'modern-light');
       }
-    }
-
-    applyDocumentTheme(storedTheme);
-    
-    if (themeDropdown) {
-      themeDropdown.addEventListener('change', (e) => {
-        const selectedTheme = e.target.value;
-        applyDocumentTheme(selectedTheme);
-        try {
-          localStorage.setItem('theme', selectedTheme);
-        } catch (err) {}
-      });
     }
 
     window.addEventListener('message', (event) => {

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -685,39 +685,6 @@ ${prismJs}
     }
 
     @media print {
-      :root,
-      [data-theme="dark"] {
-        --bg-app: #ffffff !important;
-        --bg-card: #ffffff !important;
-        --bg-bubble-user: #f1f5f9 !important;
-        --bg-bubble-ai: #ffffff !important;
-        --text-primary: #0f172a !important;
-        --text-secondary: #475569 !important;
-        --accent: #4f46e5 !important;
-        --accent-light: #e0e7ff !important;
-        --border: #e2e8f0 !important;
-        --code-bg: #0f172a !important;
-        --code-text: #f8fafc !important;
-        --code-header-bg: #1e293b !important;
-        --scrollbar-thumb: #cbd5e1 !important;
-      }
-      @page {
-        size: portrait;
-        margin: 0;
-      }
-      @media print {
-        html, body {
-          -webkit-print-color-adjust: exact !important;
-          print-color-adjust: exact !important;
-        }
-        html:not([data-theme='dark']), body:not([data-theme='dark']) {
-          background-color: #ffffff !important;
-          color: #0f172a !important;
-          width: 100% !important;
-          margin: 0 !important;
-          padding: 12mm 15mm !important;
-          box-sizing: border-box !important;
-    @media print {
       @page {
         margin: 12mm 15mm;
         size: auto;

--- a/content/formatters/markdown.js
+++ b/content/formatters/markdown.js
@@ -83,15 +83,16 @@ export class MarkdownFormatter extends ExportFormatter {
 
     output += `\n`;
 
-    messages.forEach((msg, index) => {
-      // Use "Prompt:" for user, "Response:" for model
-      const heading = msg.role === 'User' ? '## Prompt:' : '## Response:';
-      output += `${heading}\n`;
-      output += `${normalizeLatexMath(msg.content)}\n\n`;
+    const isWebArticle = platform === 'Web Article' || platform === 'WebArticle';
 
-      // Don't add separator after last message
-      if (index < messages.length - 1) {
-        // No separator needed - just blank line between messages
+    messages.forEach((msg, index) => {
+      const isArticleRole = msg.role === 'Article' || msg.role === 'Web Article';
+      if (isWebArticle || isArticleRole) {
+        output += `${normalizeLatexMath(msg.content)}\n\n`;
+      } else {
+        const heading = msg.role === 'User' ? '## Prompt:' : '## Response:';
+        output += `${heading}\n`;
+        output += `${normalizeLatexMath(msg.content)}\n\n`;
       }
     });
 

--- a/content/main.js
+++ b/content/main.js
@@ -17,6 +17,7 @@ import {
   LumoParser,
   JoylandParser,
   ChubParser,
+  ArticleParser,
 } from 'decant-core';
 
 import { MarkdownFormatter } from './formatters/markdown.js';
@@ -99,6 +100,7 @@ const parsers = [
   new LumoParser(),
   new JoylandParser(),
   new ChubParser(),
+  new ArticleParser(),
 ];
 
 // Registry of formatters

--- a/content/main.js
+++ b/content/main.js
@@ -264,7 +264,10 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
           if (request.format === 'png') {
             await ensureHtml2CanvasLoaded();
           }
-          const options = { highQuality: request.highQualityPng !== false };
+          const options = {
+            highQuality: request.highQualityPng !== false,
+            theme: request.theme,
+          };
           const formattedResult = await formatter.format(conversation, options);
           const mimeType = formatter.getMimeType();
           const blob =
@@ -354,9 +357,10 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
             });
           }
           console.log('Parsed conversation with', conversation.messages.length, 'messages');
-          const primaryContent = formatter.format(conversation);
+          const formatOptions = request.theme ? { theme: request.theme } : {};
+          const primaryContent = formatter.format(conversation, formatOptions);
           const htmlFormatter = formatters.html;
-          const richHtmlContent = htmlFormatter ? htmlFormatter.format(conversation) : null;
+          const richHtmlContent = htmlFormatter ? htmlFormatter.format(conversation, formatOptions) : null;
 
           sendResponse({
             success: true,

--- a/content/utils/sanitizer.js
+++ b/content/utils/sanitizer.js
@@ -33,7 +33,8 @@ export function sanitizeHtml(html) {
   if (purify && typeof purify.sanitize === 'function') {
     const sanitized = purify.sanitize(html, {
       USE_PROFILES: { html: true, svg: true, mathMl: true },
-      ADD_ATTR: ['target', 'rel', 'class', 'style'],
+      ADD_TAGS: ['details', 'summary', 'input'],
+      ADD_ATTR: ['target', 'rel', 'class', 'style', 'disabled', 'checked', 'type'],
     });
     if (sanitized !== undefined) {
       return sanitized

--- a/entrypoints/background.js
+++ b/entrypoints/background.js
@@ -28,47 +28,7 @@ export default defineBackground(() => {
     chub: 'https://chub.ai/',
   };
 
-  const SUPPORTED_DOCUMENT_URL_PATTERNS = [
-    '*://chatgpt.com/*',
-    '*://gemini.google.com/*',
-    '*://claude.ai/*',
-    '*://qwen.ai/*',
-    '*://chat.qwen.ai/*',
-    '*://www.perplexity.ai/*',
-    '*://chat.deepseek.com/*',
-    '*://www.meta.ai/*',
-    '*://meta.ai/*',
-    '*://chat.mistral.ai/*',
-    '*://chat.z.ai/*',
-    '*://console.cloud.google.com/*',
-    '*://aistudio.google.com/*',
-    '*://notebooklm.google.com/*',
-    '*://notebook.google.com/*',
-    '*://copilot.microsoft.com/*',
-    '*://www.copilot.microsoft.com/*',
-    '*://copilot.com/*',
-    '*://www.copilot.com/*',
-    '*://copilot.cloud.microsoft/*',
-    '*://m365.cloud.microsoft/*',
-    '*://www.m365.cloud.microsoft/*',
-    '*://www.bing.com/*',
-    '*://bing.com/*',
-    '*://edgeservices.bing.com/*',
-    '*://lumo.proton.me/*',
-    '*://joyland.ai/*',
-    '*://www.joyland.ai/*',
-    '*://chub.ai/*',
-    '*://www.chub.ai/*',
-    '*://characterhub.org/*',
-    '*://www.characterhub.org/*',
-    '*://www.google.com/*',
-    '*://www.google.co.in/*',
-    '*://www.google.co.uk/*',
-    '*://www.google.ca/*',
-    '*://www.google.com.au/*',
-    '*://www.google.de/*',
-    '*://www.google.fr/*',
-  ];
+  const SUPPORTED_DOCUMENT_URL_PATTERNS = ['<all_urls>'];
 
   function setupContextMenus() {
     if (typeof chrome === 'undefined' || !chrome.contextMenus) return;

--- a/entrypoints/background.js
+++ b/entrypoints/background.js
@@ -120,6 +120,23 @@ export default defineBackground(() => {
 
       await syncSidePanelBehavior();
       setupContextMenus();
+
+      // Inject content script into existing tabs on install/reload
+      if (typeof chrome !== 'undefined' && chrome.scripting?.executeScript && chrome.tabs?.query) {
+        try {
+          const tabs = await chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] });
+          for (const t of tabs) {
+            if (t.id) {
+              chrome.scripting.executeScript({
+                target: { tabId: t.id },
+                files: ['content-scripts/content.js'],
+              }).catch(() => {});
+            }
+          }
+        } catch (e) {
+          console.warn('[AI Exporter Background] Failed to inject content script on install:', e);
+        }
+      }
     });
   }
 

--- a/entrypoints/content.js
+++ b/entrypoints/content.js
@@ -264,7 +264,10 @@ export default defineContentScript({
               if (request.format === 'png') {
                 await ensureHtml2CanvasLoaded();
               }
-              const options = { highQuality: request.highQualityPng !== false };
+              const options = {
+                highQuality: request.highQualityPng !== false,
+                theme: request.theme,
+              };
               const formattedResult = await formatter.format(conversation, options);
               const mimeType = formatter.getMimeType();
               const blob =
@@ -362,9 +365,10 @@ export default defineContentScript({
                 });
               }
               logger.debug('Parsed conversation with', conversation.messages.length, 'messages');
-              const primaryContent = formatter.format(conversation);
+              const formatOptions = request.theme ? { theme: request.theme } : {};
+              const primaryContent = formatter.format(conversation, formatOptions);
               const htmlFormatter = formatters.html;
-              const richHtmlContent = htmlFormatter ? htmlFormatter.format(conversation) : null;
+              const richHtmlContent = htmlFormatter ? htmlFormatter.format(conversation, formatOptions) : null;
 
               sendResponse({
                 success: true,

--- a/entrypoints/content.js
+++ b/entrypoints/content.js
@@ -16,6 +16,7 @@ import {
   LumoParser,
   JoylandParser,
   ChubParser,
+  ArticleParser,
 } from 'decant-core';
 
 import { MarkdownFormatter } from '../content/formatters/markdown.js';
@@ -30,47 +31,7 @@ import { createLogger } from '../content/utils/logger.js';
 const logger = createLogger('ContentScript');
 
 export default defineContentScript({
-  matches: [
-    '*://chatgpt.com/*',
-    '*://gemini.google.com/*',
-    '*://claude.ai/*',
-    '*://qwen.ai/*',
-    '*://chat.qwen.ai/*',
-    '*://www.perplexity.ai/*',
-    '*://chat.deepseek.com/*',
-    '*://www.meta.ai/*',
-    '*://meta.ai/*',
-    '*://chat.mistral.ai/*',
-    '*://chat.z.ai/*',
-    '*://console.cloud.google.com/*',
-    '*://aistudio.google.com/*',
-    '*://notebooklm.google.com/*',
-    '*://notebook.google.com/*',
-    '*://copilot.microsoft.com/*',
-    '*://www.copilot.microsoft.com/*',
-    '*://copilot.com/*',
-    '*://www.copilot.com/*',
-    '*://copilot.cloud.microsoft/*',
-    '*://m365.cloud.microsoft/*',
-    '*://www.m365.cloud.microsoft/*',
-    '*://www.bing.com/*',
-    '*://bing.com/*',
-    '*://edgeservices.bing.com/*',
-    '*://lumo.proton.me/*',
-    '*://joyland.ai/*',
-    '*://www.joyland.ai/*',
-    '*://chub.ai/*',
-    '*://www.chub.ai/*',
-    '*://characterhub.org/*',
-    '*://www.characterhub.org/*',
-    '*://www.google.com/*',
-    '*://www.google.co.in/*',
-    '*://www.google.co.uk/*',
-    '*://www.google.ca/*',
-    '*://www.google.com.au/*',
-    '*://www.google.de/*',
-    '*://www.google.fr/*',
-  ],
+  matches: ['<all_urls>'],
   allFrames: true,
   runAt: 'document_idle',
   main() {
@@ -142,6 +103,7 @@ export default defineContentScript({
       new LumoParser(),
       new JoylandParser(),
       new ChubParser(),
+      new ArticleParser(),
     ];
 
     const formatters = {

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -32,8 +32,14 @@
               >
               <select id="theme-select" class="select-input">
                 <option value="system">System Default (Auto-detect)</option>
-                <option value="light">Light Mode</option>
-                <option value="dark">Dark Mode</option>
+                <option value="light">Modern Light</option>
+                <option value="dark">Modern Dark</option>
+                <option value="github-light">GitHub Light</option>
+                <option value="github-dark">GitHub Dark</option>
+                <option value="nord">Nord Slate</option>
+                <option value="dracula">Dracula</option>
+                <option value="solarized-light">Solarized Light</option>
+                <option value="solarized-dark">Solarized Dark</option>
               </select>
               <span class="field-help" data-i18n="themeHelp"
                 >Controls color theme for extension popup, options, and preview window.</span

--- a/entrypoints/options/options.js
+++ b/entrypoints/options/options.js
@@ -2,10 +2,8 @@ import { initI18n, applyI18n, t } from '../../content/utils/i18n.js';
 import { formatFilename, DEFAULT_FILENAME_TEMPLATE } from '../../content/utils/filename.js';
 
 function applyTheme(theme) {
-  if (theme === 'dark') {
-    document.documentElement.setAttribute('data-theme', 'dark');
-  } else if (theme === 'light') {
-    document.documentElement.setAttribute('data-theme', 'light');
+  if (theme && theme !== 'system') {
+    document.documentElement.setAttribute('data-theme', theme);
   } else {
     document.documentElement.removeAttribute('data-theme');
   }

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -51,6 +51,17 @@
             <option value="png">🖼️ Shareable Image (.png)</option>
             <option value="pdf">📄 PDF (.pdf)</option>
           </select>
+          <select id="popup-theme-select" class="theme-select" title="Select Theme">
+            <option value="system">🎨 System Theme (Default)</option>
+            <option value="modern-light">☀️ Modern Light</option>
+            <option value="modern-dark">🌙 Modern Dark</option>
+            <option value="github-light">🐙 GitHub Light</option>
+            <option value="github-dark">🐙 GitHub Dark</option>
+            <option value="nord">❄️ Nord Slate</option>
+            <option value="dracula">🧛 Dracula</option>
+            <option value="solarized-light">🌅 Solarized Light</option>
+            <option value="solarized-dark">🌌 Solarized Dark</option>
+          </select>
           <div id="png-warning-banner" class="png-warning-banner hidden" data-i18n="pngWarning">
             ⚠️ PNG export on long chats may take 1–2 minutes. Consider PDF or Markdown for instant
             export.

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -51,17 +51,6 @@
             <option value="png">🖼️ Shareable Image (.png)</option>
             <option value="pdf">📄 PDF (.pdf)</option>
           </select>
-          <select id="popup-theme-select" class="theme-select" title="Select Theme">
-            <option value="system">🎨 System Theme (Default)</option>
-            <option value="modern-light">☀️ Modern Light</option>
-            <option value="modern-dark">🌙 Modern Dark</option>
-            <option value="github-light">🐙 GitHub Light</option>
-            <option value="github-dark">🐙 GitHub Dark</option>
-            <option value="nord">❄️ Nord Slate</option>
-            <option value="dracula">🧛 Dracula</option>
-            <option value="solarized-light">🌅 Solarized Light</option>
-            <option value="solarized-dark">🌌 Solarized Dark</option>
-          </select>
           <div id="png-warning-banner" class="png-warning-banner hidden" data-i18n="pngWarning">
             ⚠️ PNG export on long chats may take 1–2 minutes. Consider PDF or Markdown for instant
             export.

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -90,23 +90,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   ]);
   applyTheme(storedSettings.theme || 'system');
 
-  const popupThemeSelect = document.getElementById('popup-theme-select');
-  if (popupThemeSelect) {
-    popupThemeSelect.value = storedSettings.theme || 'system';
-    popupThemeSelect.addEventListener('change', () => {
-      const selected = popupThemeSelect.value;
-      storedSettings.theme = selected;
-      chrome.storage.sync.set({ theme: selected });
-      applyTheme(selected);
-    });
-  }
-
   if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.onChanged) {
     chrome.storage.onChanged.addListener(async (changes, areaName) => {
       if (areaName === 'sync') {
         if (changes.theme) {
           storedSettings.theme = changes.theme.newValue || 'system';
-          if (popupThemeSelect) popupThemeSelect.value = storedSettings.theme;
           applyTheme(storedSettings.theme);
         }
         if (changes.uiLanguage) {

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -90,11 +90,24 @@ document.addEventListener('DOMContentLoaded', async () => {
   ]);
   applyTheme(storedSettings.theme || 'system');
 
+  const popupThemeSelect = document.getElementById('popup-theme-select');
+  if (popupThemeSelect) {
+    popupThemeSelect.value = storedSettings.theme || 'system';
+    popupThemeSelect.addEventListener('change', () => {
+      const selected = popupThemeSelect.value;
+      storedSettings.theme = selected;
+      chrome.storage.sync.set({ theme: selected });
+      applyTheme(selected);
+    });
+  }
+
   if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.onChanged) {
     chrome.storage.onChanged.addListener(async (changes, areaName) => {
       if (areaName === 'sync') {
         if (changes.theme) {
-          applyTheme(changes.theme.newValue || 'system');
+          storedSettings.theme = changes.theme.newValue || 'system';
+          if (popupThemeSelect) popupThemeSelect.value = storedSettings.theme;
+          applyTheme(storedSettings.theme);
         }
         if (changes.uiLanguage) {
           await initI18n(changes.uiLanguage.newValue || 'auto');

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -5,10 +5,8 @@ import { createLogger } from '../../content/utils/logger.js';
 const logger = createLogger('Popup');
 
 function applyTheme(theme) {
-  if (theme === 'dark') {
-    document.documentElement.setAttribute('data-theme', 'dark');
-  } else if (theme === 'light') {
-    document.documentElement.setAttribute('data-theme', 'light');
+  if (theme && theme !== 'system') {
+    document.documentElement.setAttribute('data-theme', theme);
   } else {
     document.documentElement.removeAttribute('data-theme');
   }
@@ -306,6 +304,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           format: formatToRequest,
           includeImages: includeImagesCheckbox.checked,
           parserMode: storedSettings.parserMode || 'auto',
+          theme: storedSettings.theme || 'system',
         });
 
         if (response && response.success) {
@@ -338,6 +337,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           customFilename: customFilename,
           highQualityPng: pngQualityCheckbox ? pngQualityCheckbox.checked : true,
           parserMode: storedSettings.parserMode || 'auto',
+          theme: storedSettings.theme || 'system',
         });
 
         if (response && response.success) {
@@ -365,6 +365,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         action: 'COPY_CHAT',
         format: format,
         includeImages: includeImagesCheckbox.checked,
+        theme: storedSettings.theme || 'system',
       });
 
       if (response && response.success) {

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -214,6 +214,19 @@ document.addEventListener('DOMContentLoaded', async () => {
       } catch (e) {
         const isNotReady = e.message && e.message.includes('Receiving end does not exist');
         logger.debug(`Attempt ${attempt + 1} communication status:`, e.message);
+        if (isNotReady && attempt === 0 && typeof chrome !== 'undefined' && chrome.scripting?.executeScript) {
+          try {
+            logger.debug('Attempting on-demand script injection for tab:', tab.id);
+            await chrome.scripting.executeScript({
+              target: { tabId: tab.id },
+              files: ['content-scripts/content.js'],
+            });
+            await new Promise((resolve) => setTimeout(resolve, 200));
+            continue;
+          } catch (injectErr) {
+            logger.debug('Dynamic script injection failed:', injectErr);
+          }
+        }
         if (!isNotReady) {
           logger.debug('Unexpected error connecting to tab:', e);
           showError();

--- a/entrypoints/preview/index.html
+++ b/entrypoints/preview/index.html
@@ -147,15 +147,15 @@
         </div>
 
         <div id="print-options-bar" class="print-options-bar hidden">
-          <label class="checkbox-label">
-            <input type="checkbox" id="page-break-prompt-checkbox" />
-            <span data-i18n="pageBreakPerPrompt">Page Break Per Prompt</span>
-          </label>
-          <label class="checkbox-label">
+          <label class="checkbox-label" id="include-toc-container">
             <input type="checkbox" id="include-toc-checkbox" />
             <span data-i18n="includeToc">Include Table of Contents</span>
           </label>
-          <span class="print-hint" style="font-size: 11.5px; color: var(--text-muted); margin-left: auto;">💡 Tip: Check "Background graphics" in the print dialog for dark/colored themes</span>
+          <label class="checkbox-label" id="page-break-container">
+            <input type="checkbox" id="page-break-prompt-checkbox" />
+            <span data-i18n="pageBreakPerPrompt">Page Break Per Prompt</span>
+          </label>
+          <span id="print-hint" class="print-hint hidden" style="font-size: 11.5px; color: var(--text-muted); margin-left: auto;">💡 Tip: Check "Background graphics" in the print dialog for dark/colored themes</span>
         </div>
 
         <div id="png-options-bar" class="png-options-bar hidden">

--- a/entrypoints/preview/index.html
+++ b/entrypoints/preview/index.html
@@ -88,6 +88,21 @@
             <button data-tab="pdf" class="control-btn" data-i18n="pdfTab">📄 PDF (.pdf)</button>
           </div>
 
+          <div class="theme-control-group">
+            <span class="transfer-label">Theme:</span>
+            <select id="preview-theme-select" class="transfer-select" title="Switch Theme">
+              <option value="system">🎨 System Theme</option>
+              <option value="modern-light">☀️ Modern Light</option>
+              <option value="modern-dark">🌙 Modern Dark</option>
+              <option value="github-light">🐙 GitHub Light</option>
+              <option value="github-dark">🐙 GitHub Dark</option>
+              <option value="nord">❄️ Nord Slate</option>
+              <option value="dracula">🧛 Dracula</option>
+              <option value="solarized-light">🌅 Solarized Light</option>
+              <option value="solarized-dark">🌌 Solarized Dark</option>
+            </select>
+          </div>
+
           <div class="transfer-control-group">
             <span class="transfer-label" data-i18n="continueOn">Continue On:</span>
             <select

--- a/entrypoints/preview/index.html
+++ b/entrypoints/preview/index.html
@@ -155,6 +155,7 @@
             <input type="checkbox" id="include-toc-checkbox" />
             <span data-i18n="includeToc">Include Table of Contents</span>
           </label>
+          <span class="print-hint" style="font-size: 11.5px; color: var(--text-muted); margin-left: auto;">💡 Tip: Check "Background graphics" in the print dialog for dark/colored themes</span>
         </div>
 
         <div id="png-options-bar" class="png-options-bar hidden">

--- a/entrypoints/preview/preview.css
+++ b/entrypoints/preview/preview.css
@@ -261,6 +261,7 @@ h1 {
   box-shadow: 0 2px 6px rgba(16, 185, 129, 0.2);
 }
 
+.theme-control-group,
 .transfer-control-group {
   display: inline-flex;
   align-items: center;

--- a/entrypoints/preview/preview.js
+++ b/entrypoints/preview/preview.js
@@ -95,6 +95,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Ignore theme loading errors when running standalone
   }
 
+  const previewThemeSelect = document.getElementById('preview-theme-select');
+  if (previewThemeSelect) {
+    previewThemeSelect.value = currentSyncTheme || 'system';
+    previewThemeSelect.addEventListener('change', () => {
+      const selected = previewThemeSelect.value;
+      currentSyncTheme = selected;
+      chrome.storage.sync.set({ theme: selected });
+      applyTheme(selected, document);
+      syncThemeToIframe(selected);
+      cachedPngBlob = null;
+      recalculateContent();
+    });
+  }
+
   const syncThemeToIframe = (theme) => {
     try {
       if (previewRendered && previewRendered.contentWindow) {
@@ -108,21 +122,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         previewRendered.contentDocument ||
         (previewRendered.contentWindow && previewRendered.contentWindow.document);
       if (!doc || !doc.documentElement) return;
-      const toggle = doc.getElementById('theme-toggle-checkbox');
-      let isDark = false;
-      if (theme === 'dark') {
-        isDark = true;
-      } else if (theme === 'light') {
-        isDark = false;
+      const themeDropdown = doc.getElementById('theme-select-dropdown');
+      if (theme && theme !== 'system') {
+        doc.documentElement.setAttribute('data-theme', theme);
+        if (themeDropdown) themeDropdown.value = theme;
       } else {
-        isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      }
-      if (isDark) {
-        doc.documentElement.setAttribute('data-theme', 'dark');
-        if (toggle) toggle.checked = true;
-      } else {
-        doc.documentElement.removeAttribute('data-theme');
-        if (toggle) toggle.checked = false;
+        const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        doc.documentElement.setAttribute('data-theme', isDark ? 'modern-dark' : 'modern-light');
+        if (themeDropdown) themeDropdown.value = isDark ? 'modern-dark' : 'modern-light';
       }
     } catch {
       // Ignore iframe DOM access error
@@ -133,8 +140,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     chrome.storage.onChanged.addListener((changes, areaName) => {
       if (areaName === 'sync' && changes.theme) {
         currentSyncTheme = changes.theme.newValue || 'system';
+        if (previewThemeSelect) previewThemeSelect.value = currentSyncTheme;
         applyTheme(currentSyncTheme, document);
         syncThemeToIframe(currentSyncTheme);
+        cachedPngBlob = null;
+        recalculateContent();
       }
     });
   }

--- a/entrypoints/preview/preview.js
+++ b/entrypoints/preview/preview.js
@@ -412,27 +412,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     const filteredMessages = conversation.messages.filter((_, idx) => selectedIndices.has(idx));
     const activeConv = { ...conversation, messages: filteredMessages };
 
-    let activeHtml = htmlFormatter.format(activeConv, { theme: currentSyncTheme });
+    const shouldIncludeToc = Boolean(includeTocCheckbox && includeTocCheckbox.checked);
 
-    if (includeTocCheckbox && includeTocCheckbox.checked && filteredMessages.length > 0) {
-      const tocItems = filteredMessages
-        .map((m, i) => {
-          const label = m.role === 'User' ? 'User' : conversation.metadata?.Source || 'Assistant';
-          const snippet = (m.content || '')
-            .replace(/<[^>]*>/g, '')
-            .trim()
-            .substring(0, 50);
-          return `<li><a href="#msg-card-${i}"><strong>${label}:</strong> ${snippet}</a></li>`;
-        })
-        .join('');
-      const tocHtml = `<div class="toc-container" style="padding:12px;margin-bottom:16px;background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;"><strong>Table of Contents</strong><ul style="margin:8px 0 0 20px;padding:0;">${tocItems}</ul></div>`;
-      activeHtml = activeHtml.replace(
-        '<div class="message-card',
-        `${tocHtml}<div class="message-card`,
-      );
-    }
-
-    htmlContent = activeHtml;
+    htmlContent = htmlFormatter.format(activeConv, {
+      theme: currentSyncTheme,
+      includeToc: shouldIncludeToc,
+    });
     markdownContent = markdownFormatter.format(activeConv);
     jsonContent = jsonFormatter.format(activeConv);
     docContent = docFormatter.format(activeConv);
@@ -574,7 +559,17 @@ document.addEventListener('DOMContentLoaded', async () => {
       pngOptionsBar.classList.toggle('hidden', tabName !== 'png');
     }
     if (printOptionsBar) {
-      printOptionsBar.classList.toggle('hidden', tabName !== 'pdf');
+      const isHtmlOrPdf = tabName === 'html-render' || tabName === 'pdf';
+      printOptionsBar.classList.toggle('hidden', !isHtmlOrPdf);
+
+      const pageBreakContainer = document.getElementById('page-break-container');
+      if (pageBreakContainer) {
+        pageBreakContainer.classList.toggle('hidden', tabName !== 'pdf');
+      }
+      const printHint = document.getElementById('print-hint');
+      if (printHint) {
+        printHint.classList.toggle('hidden', tabName !== 'pdf');
+      }
     }
 
     // Contextual copy button: hide on png, pdf, and doc; show on text code/markup formats

--- a/entrypoints/preview/preview.js
+++ b/entrypoints/preview/preview.js
@@ -497,7 +497,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       const doc =
         previewRendered.contentDocument ||
         (previewRendered.contentWindow && previewRendered.contentWindow.document);
-      if (doc && doc.head) {
+      if (doc && doc.documentElement) {
+        if (currentSyncTheme && currentSyncTheme !== 'system') {
+          doc.documentElement.setAttribute('data-theme', currentSyncTheme);
+        } else {
+          const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          doc.documentElement.setAttribute('data-theme', isDark ? 'modern-dark' : 'modern-light');
+        }
         let printStyle = doc.getElementById('print-custom-style');
         if (!printStyle) {
           printStyle = doc.createElement('style');

--- a/entrypoints/preview/preview.js
+++ b/entrypoints/preview/preview.js
@@ -33,10 +33,8 @@ function injectPreviewStyles(doc) {
 
 function applyTheme(theme, targetDoc = document) {
   if (!targetDoc || !targetDoc.documentElement) return;
-  if (theme === 'dark') {
-    targetDoc.documentElement.setAttribute('data-theme', 'dark');
-  } else if (theme === 'light') {
-    targetDoc.documentElement.setAttribute('data-theme', 'light');
+  if (theme && theme !== 'system') {
+    targetDoc.documentElement.setAttribute('data-theme', theme);
   } else {
     targetDoc.documentElement.removeAttribute('data-theme');
   }
@@ -404,7 +402,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const filteredMessages = conversation.messages.filter((_, idx) => selectedIndices.has(idx));
     const activeConv = { ...conversation, messages: filteredMessages };
 
-    let activeHtml = htmlFormatter.format(activeConv);
+    let activeHtml = htmlFormatter.format(activeConv, { theme: currentSyncTheme });
 
     if (includeTocCheckbox && includeTocCheckbox.checked && filteredMessages.length > 0) {
       const tocItems = filteredMessages
@@ -696,7 +694,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.title = `${effectiveFilename} - Chat Export Preview`;
 
     if (conversation) {
-      htmlContent = htmlFormatter.format(conversation);
+      htmlContent = htmlFormatter.format(conversation, { theme: currentSyncTheme });
       markdownContent = markdownFormatter.format(conversation);
       jsonContent = jsonFormatter.format(conversation);
       docContent = docFormatter.format(conversation);

--- a/entrypoints/preview/preview.js
+++ b/entrypoints/preview/preview.js
@@ -574,7 +574,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       pngOptionsBar.classList.toggle('hidden', tabName !== 'png');
     }
     if (printOptionsBar) {
-      printOptionsBar.classList.toggle('hidden', tabName !== 'html-render' && tabName !== 'pdf');
+      printOptionsBar.classList.toggle('hidden', tabName !== 'pdf');
     }
 
     // Contextual copy button: hide on png, pdf, and doc; show on text code/markup formats

--- a/tests/html-formatter.test.mjs
+++ b/tests/html-formatter.test.mjs
@@ -73,7 +73,7 @@ test('HTML formatter converts parsed conversation into structured HTML document'
   assert.ok(output.includes('Model: GPT-4'));
   assert.ok(output.includes('Method: API'));
   assert.ok(output.includes('Self-Consistency Test</h1>'));
-  assert.ok(output.includes('theme-select-dropdown'));
+  assert.ok(output.includes('theme-toggle-checkbox'));
   assert.ok(output.includes('data-theme="modern-dark"'));
   assert.ok(output.includes('data-theme="nord"'));
 

--- a/tests/html-formatter.test.mjs
+++ b/tests/html-formatter.test.mjs
@@ -73,7 +73,9 @@ test('HTML formatter converts parsed conversation into structured HTML document'
   assert.ok(output.includes('Model: GPT-4'));
   assert.ok(output.includes('Method: API'));
   assert.ok(output.includes('Self-Consistency Test</h1>'));
-  assert.ok(output.includes('theme-toggle-checkbox'));
+  assert.ok(output.includes('theme-select-dropdown'));
+  assert.ok(output.includes('data-theme="modern-dark"'));
+  assert.ok(output.includes('data-theme="nord"'));
 
   // Check message cards and styling
   assert.ok(output.includes('message-card role-user'));

--- a/tests/html-formatter.test.mjs
+++ b/tests/html-formatter.test.mjs
@@ -73,7 +73,7 @@ test('HTML formatter converts parsed conversation into structured HTML document'
   assert.ok(output.includes('Model: GPT-4'));
   assert.ok(output.includes('Method: API'));
   assert.ok(output.includes('Self-Consistency Test</h1>'));
-  assert.ok(output.includes('theme-toggle-checkbox'));
+  assert.ok(output.includes('theme-select-dropdown'));
   assert.ok(output.includes('data-theme="modern-dark"'));
   assert.ok(output.includes('data-theme="nord"'));
 

--- a/tests/html-formatter.test.mjs
+++ b/tests/html-formatter.test.mjs
@@ -73,7 +73,6 @@ test('HTML formatter converts parsed conversation into structured HTML document'
   assert.ok(output.includes('Model: GPT-4'));
   assert.ok(output.includes('Method: API'));
   assert.ok(output.includes('Self-Consistency Test</h1>'));
-  assert.ok(output.includes('theme-select-dropdown'));
   assert.ok(output.includes('data-theme="modern-dark"'));
   assert.ok(output.includes('data-theme="nord"'));
 

--- a/tests/web-article-parser.test.mjs
+++ b/tests/web-article-parser.test.mjs
@@ -1,0 +1,52 @@
+import { parseHTML } from 'linkedom';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+// Set up Linkedom DOM context
+const { window, document, HTMLElement, Node, DOMParser } = parseHTML(`
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <title>Sample Tech Article - Covai Blog</title>
+      <meta name="author" content="Jane Doe" />
+      <meta property="og:site_name" content="Covai Tech Blog" />
+    </head>
+    <body>
+      <main>
+        <h1>Sample Tech Article</h1>
+        <p>This is a tech blog post about web browser extension development and decant-core parser architecture.</p>
+        <p>It contains multiple paragraphs explaining how Readability, Defuddle, and Article-Extractor work together seamlessly.</p>
+      </main>
+    </body>
+  </html>
+`);
+
+global.window = window;
+global.document = document;
+global.HTMLElement = HTMLElement;
+global.Node = Node;
+global.DOMParser = DOMParser;
+
+const { ArticleParser } = await import('decant-core');
+
+test('ArticleParser is available for standard http/https URLs', () => {
+  const parser = new ArticleParser();
+  assert.equal(parser.isAvailable('https://example.com/blog/article'), true);
+  assert.equal(parser.isAvailable('http://news.ycombinator.com'), true);
+  assert.equal(parser.isAvailable('file:///local/document.html'), true);
+  assert.equal(parser.isAvailable('invalid-url'), false);
+});
+
+test('ArticleParser extracts web page title, metadata, and body content', async () => {
+  const parser = new ArticleParser();
+  window.location = { href: 'https://covai.org/blog/sample-tech-article' };
+
+  const conversation = await parser.parse();
+
+  assert.equal(conversation.title, 'Sample Tech Article');
+  assert.equal(conversation.messages.length, 1);
+  assert.equal(conversation.messages[0].role, 'Assistant');
+  assert.ok(conversation.messages[0].content.includes('tech blog post'));
+  assert.equal(conversation.metadata.Source, 'Covai Tech Blog');
+  assert.equal(conversation.metadata.Author, 'Jane Doe');
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -58,45 +58,20 @@ export default defineConfig({
   manifest: ({ browser }) => {
     const isFirefox = browser === 'firefox';
 
-    const permissions = ['activeTab', 'storage', 'contextMenus'];
+    const permissions = [
+      'activeTab',
+      'tabs',
+      'downloads',
+      'scripting',
+      'storage',
+      'contextMenus',
+      'clipboardWrite',
+    ];
     if (!isFirefox) {
       permissions.push('sidePanel');
     }
 
-    const hostPermissions = [
-      '*://chatgpt.com/*',
-      '*://gemini.google.com/*',
-      '*://claude.ai/*',
-      '*://qwen.ai/*',
-      '*://chat.qwen.ai/*',
-      '*://www.perplexity.ai/*',
-      '*://chat.deepseek.com/*',
-      '*://www.meta.ai/*',
-      '*://meta.ai/*',
-      '*://chat.mistral.ai/*',
-      '*://chat.z.ai/*',
-      '*://console.cloud.google.com/*',
-      '*://aistudio.google.com/*',
-      '*://notebooklm.google.com/*',
-      '*://notebook.google.com/*',
-      '*://copilot.microsoft.com/*',
-      '*://www.copilot.microsoft.com/*',
-      '*://copilot.com/*',
-      '*://www.copilot.com/*',
-      '*://copilot.cloud.microsoft/*',
-      '*://m365.cloud.microsoft/*',
-      '*://www.m365.cloud.microsoft/*',
-      '*://www.bing.com/*',
-      '*://bing.com/*',
-      '*://edgeservices.bing.com/*',
-      '*://lumo.proton.me/*',
-      '*://joyland.ai/*',
-      '*://www.joyland.ai/*',
-      '*://chub.ai/*',
-      '*://www.chub.ai/*',
-      '*://characterhub.org/*',
-      '*://www.characterhub.org/*',
-    ];
+    const hostPermissions = ['<all_urls>'];
 
     const baseManifest: any = {
       default_locale: 'en',
@@ -155,7 +130,7 @@ export default defineConfig({
             'schemas/*',
             '_locales/*',
           ],
-          matches: hostPermissions,
+          matches: ['<all_urls>'],
         },
       ],
     };

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -128,7 +128,6 @@ export default defineConfig({
             'content/claude_react_reader.js',
             'content/lib/*',
             'schemas/*',
-            '_locales/*',
           ],
           matches: ['<all_urls>'],
         },


### PR DESCRIPTION
## Description
This PR enables `ai-chat-exporter` to export any web page (not just AI chats) using `decant-core`'s `ArticleParser`, matching the capabilities of `decant`.

### Summary of Changes
1. **Web Page Export Support**: Integrated `ArticleParser` from `decant-core` into content scripts and fallback parsers.
2. **Permissions Expansion**: Expanded `host_permissions` and content script matches to `<all_urls>`, and added `tabs`, `downloads`, `scripting`, and `clipboardWrite` permissions.
3. **Multi-Theme Export Options**: Added interactive theme selection (`Modern Light/Dark`, `GitHub Light/Dark`, `Nord Slate`, `Dracula`, `Solarized Light/Dark`) in exported HTML and preview UI.
4. **Clean Web Article Formatting**: Reader-focused article layout for web page exports without artificial AI chat bubbles or response headings.
5. **Data Completeness & Sanitization**: Preserved collapsible reasoning (`<details>`) and task list checkboxes in DOMPurify sanitization.
6. **Tests**: Added unit tests for `ArticleParser` web page extraction and HTML theme rendering. All 133 unit tests pass across `decant-core`, `decant`, and `ai-chat-exporter`.