### PR TITLE
feat: move base64 images to bottom references, add robust image stripping and global preview toggle

### DIFF
--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -1106,6 +1106,30 @@ export function escapeHtml(str) {
     .replace(/'/g, '&#039;');
 }
 
+export function sanitizeUrl(url, isImage = false) {
+  if (!url || typeof url !== 'string') return '';
+  let trimmed = url.trim().replace(/^<|>$/g, '');
+  trimmed = trimmed.replace(/&amp;/g, '&');
+  if (isImage) {
+    if (/^(?:https?:|data:image(?:\/|\\\/)|blob:|\/|\.\/)/i.test(trimmed)) {
+      return trimmed
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+    return '';
+  }
+  if (/^(?:https?:|mailto:|tel:|#|\/|\.\/)/i.test(trimmed)) {
+    return trimmed
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+  return '';
+}
+
 function cleanLatexMath(latex) {
   if (!latex || typeof latex !== 'string') return '';
   return latex.replace(/\\\\([a-zA-Z]+)/g, '\\$1').replace(/\\([_\][*])/g, '$1');
@@ -1185,7 +1209,8 @@ function inlineParse(text, mathBlockPlaceholders = null, referenceDefs = null) {
 
   // 6.5 Replace images ![alt](url)
   text = text.replace(/!\[(.*?)\]\((.*?)\)/g, (match, altText, url) => {
-    const safeUrl = url.replace(/&amp;/g, '&');
+    const safeUrl = sanitizeUrl(url, true);
+    if (!safeUrl) return '';
     return `<img src="${safeUrl}" alt="${altText}" style="max-width: 350px; width: 100%; height: auto; border-radius: 8px; margin: 0.5rem 0; display: block;" />`;
   });
 
@@ -1195,7 +1220,8 @@ function inlineParse(text, mathBlockPlaceholders = null, referenceDefs = null) {
       const key = (refId || altText).trim().toLowerCase();
       const url = referenceDefs.get(key);
       if (url) {
-        const safeUrl = url.replace(/&amp;/g, '&');
+        const safeUrl = sanitizeUrl(url, true);
+        if (!safeUrl) return '';
         return `<img src="${safeUrl}" alt="${altText}" style="max-width: 350px; width: 100%; height: auto; border-radius: 8px; margin: 0.5rem 0; display: block;" />`;
       }
       return match;
@@ -1204,7 +1230,8 @@ function inlineParse(text, mathBlockPlaceholders = null, referenceDefs = null) {
 
   // 7. Replace links [text](url)
   text = text.replace(/\[(.*?)\]\((.*?)\)/g, (match, linkText, url) => {
-    const safeUrl = url.replace(/&amp;/g, '&');
+    const safeUrl = sanitizeUrl(url, false);
+    if (!safeUrl) return linkText;
     return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${linkText}</a>`;
   });
 
@@ -1214,7 +1241,8 @@ function inlineParse(text, mathBlockPlaceholders = null, referenceDefs = null) {
       const key = (refId || linkText).trim().toLowerCase();
       const url = referenceDefs.get(key);
       if (url) {
-        const safeUrl = url.replace(/&amp;/g, '&');
+        const safeUrl = sanitizeUrl(url, false);
+        if (!safeUrl) return linkText;
         return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${linkText}</a>`;
       }
       return match;

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -1111,7 +1111,7 @@ function cleanLatexMath(latex) {
   return latex.replace(/\\\\([a-zA-Z]+)/g, '\\$1').replace(/\\([_\][*])/g, '$1');
 }
 
-function inlineParse(text, mathBlockPlaceholders = null) {
+function inlineParse(text, mathBlockPlaceholders = null, referenceDefs = null) {
   const placeholders = [];
   let tokenCounter = 0;
 
@@ -1189,11 +1189,37 @@ function inlineParse(text, mathBlockPlaceholders = null) {
     return `<img src="${safeUrl}" alt="${altText}" style="max-width: 350px; width: 100%; height: auto; border-radius: 8px; margin: 0.5rem 0; display: block;" />`;
   });
 
+  // Reference-style images ![alt][label]
+  if (referenceDefs && referenceDefs.size > 0) {
+    text = text.replace(/!\[(.*?)\]\[(.*?)\]/g, (match, altText, refId) => {
+      const key = (refId || altText).trim().toLowerCase();
+      const url = referenceDefs.get(key);
+      if (url) {
+        const safeUrl = url.replace(/&amp;/g, '&');
+        return `<img src="${safeUrl}" alt="${altText}" style="max-width: 350px; width: 100%; height: auto; border-radius: 8px; margin: 0.5rem 0; display: block;" />`;
+      }
+      return match;
+    });
+  }
+
   // 7. Replace links [text](url)
   text = text.replace(/\[(.*?)\]\((.*?)\)/g, (match, linkText, url) => {
     const safeUrl = url.replace(/&amp;/g, '&');
     return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${linkText}</a>`;
   });
+
+  // Reference-style links [text][label]
+  if (referenceDefs && referenceDefs.size > 0) {
+    text = text.replace(/\[(.*?)\]\[(.*?)\]/g, (match, linkText, refId) => {
+      const key = (refId || linkText).trim().toLowerCase();
+      const url = referenceDefs.get(key);
+      if (url) {
+        const safeUrl = url.replace(/&amp;/g, '&');
+        return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${linkText}</a>`;
+      }
+      return match;
+    });
+  }
 
   // 8. Restore escape placeholders first
   escapePlaceholders.forEach(({ id, char }) => {
@@ -1217,7 +1243,7 @@ function inlineParse(text, mathBlockPlaceholders = null) {
   return text;
 }
 
-function renderTable(rows, mathBlockPlaceholders = null) {
+function renderTable(rows, mathBlockPlaceholders = null, referenceDefs = null) {
   if (rows.length === 0) return '';
 
   const isSeparator = (r) => /^[|\s:-]+$/.test(r);
@@ -1258,7 +1284,7 @@ function renderTable(rows, mathBlockPlaceholders = null) {
     tableHtml += '<thead><tr>\n';
     headerCells.forEach((cell, idx) => {
       const align = alignments[idx] ? ` style="text-align: ${alignments[idx]};"` : '';
-      tableHtml += `  <th${align}>${inlineParse(cell, mathBlockPlaceholders)}</th>\n`;
+      tableHtml += `  <th${align}>${inlineParse(cell, mathBlockPlaceholders, referenceDefs)}</th>\n`;
     });
     tableHtml += '</tr></thead>\n';
   }
@@ -1269,7 +1295,7 @@ function renderTable(rows, mathBlockPlaceholders = null) {
       tableHtml += '<tr>\n';
       row.forEach((cell, idx) => {
         const align = alignments[idx] ? ` style="text-align: ${alignments[idx]};"` : '';
-        tableHtml += `  <td${align}>${inlineParse(cell, mathBlockPlaceholders)}</td>\n`;
+        tableHtml += `  <td${align}>${inlineParse(cell, mathBlockPlaceholders, referenceDefs)}</td>\n`;
       });
       tableHtml += '</tr>\n';
     });
@@ -1336,6 +1362,18 @@ export function markdownToHtml(mdText) {
     mdText = mdText.replace(id, () => content);
   }
 
+  // 7. Extract reference link / image definitions: [label]: url or [label]: <url>
+  const referenceDefs = new Map();
+  mdText = mdText.replace(
+    /^\s*\[([^\]]+)\]:\s*<?(\S+?)>?(?:\s+["'(].*?["')])?\s*$/gm,
+    (match, label, url) => {
+      referenceDefs.set(label.trim().toLowerCase(), url.trim());
+      return '';
+    },
+  );
+
+  const parseInline = (text) => inlineParse(text, mathBlockPlaceholders, referenceDefs);
+
   const lines = mdText.split(/\r?\n/);
   let html = '';
 
@@ -1382,19 +1420,19 @@ export function markdownToHtml(mdText) {
     }
 
     if (inTable) {
-      html += renderTable(tableRows, mathBlockPlaceholders);
+      html += renderTable(tableRows, mathBlockPlaceholders, referenceDefs);
       inTable = false;
       tableRows = [];
     }
 
     if (inBlockquote) {
-      html += `<blockquote>${blockquoteContent.map((l) => inlineParse(l, mathBlockPlaceholders)).join('<br>\n')}</blockquote>\n`;
+      html += `<blockquote>${blockquoteContent.map((l) => parseInline(l)).join('<br>\n')}</blockquote>\n`;
       inBlockquote = false;
       blockquoteContent = [];
     }
 
     if (inParagraph) {
-      html += `<p>${paragraphContent.map((l) => inlineParse(l, mathBlockPlaceholders)).join('<br>\n')}</p>\n`;
+      html += `<p>${paragraphContent.map((l) => parseInline(l)).join('<br>\n')}</p>\n`;
       inParagraph = false;
       paragraphContent = [];
     }
@@ -1458,7 +1496,7 @@ export function markdownToHtml(mdText) {
       closeAllBlocks();
       const level = headingMatch[1].length;
       const text = headingMatch[2];
-      html += `<h${level}>${inlineParse(text, mathBlockPlaceholders)}</h${level}>\n`;
+      html += `<h${level}>${parseInline(text)}</h${level}>\n`;
       continue;
     }
 
@@ -1504,9 +1542,9 @@ export function markdownToHtml(mdText) {
         html += `<ul${isTask ? ' class="task-list"' : ''}>\n`;
       }
       if (isTask) {
-        html += `<li class="task-list-item"><input type="checkbox" class="task-checkbox" disabled${isChecked ? ' checked' : ''}><span>${inlineParse(itemContent, mathBlockPlaceholders)}</span></li>\n`;
+        html += `<li class="task-list-item"><input type="checkbox" class="task-checkbox" disabled${isChecked ? ' checked' : ''}><span>${parseInline(itemContent)}</span></li>\n`;
       } else {
-        html += `<li>${inlineParse(itemContent, mathBlockPlaceholders)}</li>\n`;
+        html += `<li>${parseInline(itemContent)}</li>\n`;
       }
       continue;
     }
@@ -1521,7 +1559,7 @@ export function markdownToHtml(mdText) {
         listType = 'ol';
         html += `<ol>\n`;
       }
-      html += `<li>${inlineParse(olMatch[2], mathBlockPlaceholders)}</li>\n`;
+      html += `<li>${parseInline(olMatch[2])}</li>\n`;
       continue;
     }
 

--- a/content/formatters/markdown.js
+++ b/content/formatters/markdown.js
@@ -61,6 +61,27 @@ export function normalizeLatexMath(text) {
   return processed;
 }
 
+export function extractBase64ImagesToReference(
+  text,
+  imageCounter = { count: 1 },
+  definitions = [],
+) {
+  if (!text || typeof text !== 'string') return { text: '', definitions };
+
+  // Match markdown images with data:image/ URIs (including escaped slashes or line breaks in base64)
+  const processed = text.replace(
+    /!\[([\s\S]*?)\]\((data:image(?:\/|\\\/)[a-zA-Z0-9+.-]+;base64,[A-Za-z0-9+/=\s\\]+)\)/gi,
+    (match, alt, dataUri) => {
+      const label = `image-${imageCounter.count++}`;
+      const cleanUri = dataUri.replace(/\\\//g, '/').replace(/\s+/g, '');
+      definitions.push(`[${label}]: ${cleanUri}`);
+      return `![${alt}][${label}]`;
+    },
+  );
+
+  return { text: processed, definitions };
+}
+
 export class MarkdownFormatter extends ExportFormatter {
   format(conversation) {
     const { title, messages } = conversation;
@@ -107,17 +128,30 @@ export class MarkdownFormatter extends ExportFormatter {
     output += `\n`;
 
     const isWebArticle = platform === 'Web Article' || platform === 'WebArticle';
+    const imageCounter = { count: 1 };
+    const imageDefinitions = [];
 
     messages.forEach((msg) => {
       const isArticleRole = msg.role === 'Article' || msg.role === 'Web Article';
+      const normalized = normalizeLatexMath(msg.content);
+      const { text: processedContent } = extractBase64ImagesToReference(
+        normalized,
+        imageCounter,
+        imageDefinitions,
+      );
+
       if (isWebArticle || isArticleRole) {
-        output += `${normalizeLatexMath(msg.content)}\n\n`;
+        output += `${processedContent}\n\n`;
       } else {
         const heading = msg.role === 'User' ? '## Prompt:' : '## Response:';
         output += `${heading}\n`;
-        output += `${normalizeLatexMath(msg.content)}\n\n`;
+        output += `${processedContent}\n\n`;
       }
     });
+
+    if (imageDefinitions.length > 0) {
+      output += `<!-- Image References -->\n\n${imageDefinitions.join('\n\n')}\n\n`;
+    }
 
     return output;
   }

--- a/content/formatters/markdown.js
+++ b/content/formatters/markdown.js
@@ -65,14 +65,27 @@ export function extractBase64ImagesToReference(
   text,
   imageCounter = { count: 1 },
   definitions = [],
+  occupiedLabels = new Set(),
 ) {
   if (!text || typeof text !== 'string') return { text: '', definitions };
+
+  // Collect existing reference labels from text to avoid collisions
+  const labelMatches = text.match(/\[([^\]]+)\]/g);
+  if (labelMatches) {
+    labelMatches.forEach((m) => {
+      occupiedLabels.add(m.slice(1, -1).trim().toLowerCase());
+    });
+  }
 
   // Match markdown images with data:image/ URIs (including escaped slashes or line breaks in base64)
   const processed = text.replace(
     /!\[([\s\S]*?)\]\((data:image(?:\/|\\\/)[a-zA-Z0-9+.-]+;base64,[A-Za-z0-9+/=\s\\]+)\)/gi,
     (match, alt, dataUri) => {
+      while (occupiedLabels.has(`image-${imageCounter.count}`.toLowerCase())) {
+        imageCounter.count++;
+      }
       const label = `image-${imageCounter.count++}`;
+      occupiedLabels.add(label.toLowerCase());
       const cleanUri = dataUri.replace(/\\\//g, '/').replace(/\s+/g, '');
       definitions.push(`[${label}]: ${cleanUri}`);
       return `![${alt}][${label}]`;
@@ -130,6 +143,19 @@ export class MarkdownFormatter extends ExportFormatter {
     const isWebArticle = platform === 'Web Article' || platform === 'WebArticle';
     const imageCounter = { count: 1 };
     const imageDefinitions = [];
+    const occupiedLabels = new Set();
+
+    // Pre-collect existing reference labels across all messages
+    messages.forEach((msg) => {
+      if (msg.content && typeof msg.content === 'string') {
+        const matches = msg.content.match(/\[([^\]]+)\]/g);
+        if (matches) {
+          matches.forEach((m) => {
+            occupiedLabels.add(m.slice(1, -1).trim().toLowerCase());
+          });
+        }
+      }
+    });
 
     messages.forEach((msg) => {
       const isArticleRole = msg.role === 'Article' || msg.role === 'Web Article';
@@ -138,6 +164,7 @@ export class MarkdownFormatter extends ExportFormatter {
         normalized,
         imageCounter,
         imageDefinitions,
+        occupiedLabels,
       );
 
       if (isWebArticle || isArticleRole) {

--- a/content/utils/strip-images.js
+++ b/content/utils/strip-images.js
@@ -42,7 +42,7 @@ export function stripImages(content) {
 
   // Track reference labels still used by ordinary markdown text links: [text][label]
   const textLinkRefLabels = new Set();
-  const textLinkRegex = /(?:^|[^!])\[([^\]]+)\]\[([^\]]*)\]/g;
+  const textLinkRegex = /(?<!!)\[([^\]]+)\]\[([^\]]*)\]/g;
   let textLinkMatch;
   while ((textLinkMatch = textLinkRegex.exec(cleaned)) !== null) {
     const key = (textLinkMatch[2] || textLinkMatch[1]).trim().toLowerCase();

--- a/content/utils/strip-images.js
+++ b/content/utils/strip-images.js
@@ -40,13 +40,26 @@ export function stripImages(content) {
     return '';
   });
 
+  // Track reference labels still used by ordinary markdown text links: [text][label]
+  const textLinkRefLabels = new Set();
+  const textLinkRegex = /(?:^|[^!])\[([^\]]+)\]\[([^\]]*)\]/g;
+  let textLinkMatch;
+  while ((textLinkMatch = textLinkRegex.exec(cleaned)) !== null) {
+    const key = (textLinkMatch[2] || textLinkMatch[1]).trim().toLowerCase();
+    if (key) textLinkRefLabels.add(key);
+  }
+
   // 1.6. Remove reference definitions for base64 images OR references matching stripped images
+  // (unless still used by an ordinary text link)
   cleaned = cleaned.replace(
     /^\s*\[([^\]]+)\]:\s*<?(\S+?)>?(?:\s+["'(].*?["')])?\s*$/gm,
     (match, label, url) => {
       const lowerLabel = label.trim().toLowerCase();
       const isDataImage = /^data:image(?:\/|\\\/)/i.test(url.trim());
-      if (isDataImage || strippedRefLabels.has(lowerLabel)) {
+      if (
+        isDataImage ||
+        (strippedRefLabels.has(lowerLabel) && !textLinkRefLabels.has(lowerLabel))
+      ) {
         return '';
       }
       return match;
@@ -78,19 +91,19 @@ export function stripImages(content) {
   cleaned = cleaned.replace(/\*\*Images:\*\*\s*(?=\*\*|$)/gi, '');
 
   // 7. Clean up ChatGPT style "**Attachments & Images:**" section header if it has no items left
-  // Only remove the header and empty list lines up to the next section or end, preserving subsequent text
-  cleaned = cleaned.replace(
-    /\*\*Attachments & Images:\*\*(?:\r?\n\s*[-*+]\s*)*(?=\r?\n\s*(?:[#*]|\S|$)|$)/gi,
-    (match, offset, fullText) => {
-      const rest = fullText.slice(offset + match.length);
-      const nextSectionIndex = rest.search(/\n\s*(?:#|\*\*)/);
-      const segment = nextSectionIndex !== -1 ? rest.slice(0, nextSectionIndex) : rest;
-      if (!/^\s*[-*+]\s+\S/m.test(segment)) {
-        return '';
-      }
-      return match;
-    },
-  );
+  const attachHeader = '**Attachments & Images:**';
+  const headerIdx = cleaned.indexOf(attachHeader);
+  if (headerIdx !== -1) {
+    const afterHeader = cleaned.slice(headerIdx + attachHeader.length);
+    const nextHeadingMatch = afterHeader.search(/\n\s*(?:#|\*\*)/);
+    const sectionBody =
+      nextHeadingMatch !== -1 ? afterHeader.slice(0, nextHeadingMatch) : afterHeader;
+    if (!/^\s*[-*+]\s+\S/m.test(sectionBody)) {
+      const remainder = nextHeadingMatch !== -1 ? afterHeader.slice(nextHeadingMatch) : '';
+      cleaned =
+        cleaned.slice(0, headerIdx).trimEnd() + (remainder ? '\n\n' + remainder.trimStart() : '');
+    }
+  }
 
   // 8. Restore protected code blocks in reverse order
   for (let i = placeholders.length - 1; i >= 0; i--) {

--- a/content/utils/strip-images.js
+++ b/content/utils/strip-images.js
@@ -12,16 +12,58 @@ export function stripImages(content) {
   if (!content || typeof content !== 'string') return '';
 
   let cleaned = content;
+  const placeholders = [];
+  let tokenCounter = 0;
 
-  // 1. Remove markdown images: ![alt](url) (using [\\s\\S]*? to handle multi-line base64 URLs)
+  // 0. Protect fenced code blocks (```...``` or ~~~...~~~)
+  cleaned = cleaned.replace(/(```[\s\S]*?```|~~~[\s\S]*?~~~)/g, (match) => {
+    const id = `__CODE_BLOCK_PLACEHOLDER_${tokenCounter++}__`;
+    placeholders.push({ id, content: match });
+    return id;
+  });
+
+  // 0.5. Protect inline code spans (`...`)
+  cleaned = cleaned.replace(/(`+)([\s\S]*?)\1/g, (match) => {
+    const id = `__INLINE_CODE_PLACEHOLDER_${tokenCounter++}__`;
+    placeholders.push({ id, content: match });
+    return id;
+  });
+
+  // 1. Remove markdown inline images: ![alt](url)
   cleaned = cleaned.replace(/!\[[\s\S]*?\]\([\s\S]*?\)/g, '');
+
+  // 1.5. Remove reference-style images: ![alt][label] and ![alt][]
+  const strippedRefLabels = new Set();
+  cleaned = cleaned.replace(/!\[([\s\S]*?)\]\[([\s\S]*?)\]/g, (match, alt, refId) => {
+    const key = (refId || alt).trim().toLowerCase();
+    if (key) strippedRefLabels.add(key);
+    return '';
+  });
+
+  // 1.6. Remove reference definitions for base64 images OR references matching stripped images
+  cleaned = cleaned.replace(
+    /^\s*\[([^\]]+)\]:\s*<?(\S+?)>?(?:\s+["'(].*?["')])?\s*$/gm,
+    (match, label, url) => {
+      const lowerLabel = label.trim().toLowerCase();
+      const isDataImage = /^data:image(?:\/|\\\/)/i.test(url.trim());
+      if (isDataImage || strippedRefLabels.has(lowerLabel)) {
+        return '';
+      }
+      return match;
+    },
+  );
+
+  // Remove comment section for image references if left alone
+  cleaned = cleaned.replace(/<!--\s*Image References\s*-->/gi, '');
 
   // 2. Remove HTML img tags: <img ... /> or <img ...>
   cleaned = cleaned.replace(/<img\b[\s\S]*?\/?>/gi, '');
 
   // 3. Remove leaked Google Search AI / SGE image injection scripts:
-  // e.g. sn._setImageSrc('...', 'data:image...') or sn.\_setImageSrc(...)
-  cleaned = cleaned.replace(/(?:google\.)?(?:sn\.)?\\?_setImageSrc\s*\([\s\S]*?\);?/gi, '');
+  cleaned = cleaned.replace(
+    /(?:google\.)?(?:sn\.)?\\?_setImageSrc\s*\(\s*['"][^'"]*['"]\s*,\s*['"][^'"]*['"]\s*\);?/gi,
+    '',
+  );
 
   // 4. Remove standalone base64 data URIs (delimited by boundary, quotes, or whitespace)
   cleaned = cleaned.replace(
@@ -35,16 +77,28 @@ export function stripImages(content) {
   // 6. Clean up ChatGPT style "**Images:**" header if left empty
   cleaned = cleaned.replace(/\*\*Images:\*\*\s*(?=\*\*|$)/gi, '');
 
-  // 7. Clean up ChatGPT style "**Attachments & Images:**" section if it has no items left
-  const attachmentSectionIndex = cleaned.indexOf('**Attachments & Images:**');
-  if (attachmentSectionIndex !== -1) {
-    const afterHeader = cleaned.slice(attachmentSectionIndex + '**Attachments & Images:**'.length);
-    if (!/- \S/g.test(afterHeader)) {
-      cleaned = cleaned.slice(0, attachmentSectionIndex);
-    }
+  // 7. Clean up ChatGPT style "**Attachments & Images:**" section header if it has no items left
+  // Only remove the header and empty list lines up to the next section or end, preserving subsequent text
+  cleaned = cleaned.replace(
+    /\*\*Attachments & Images:\*\*(?:\r?\n\s*[-*+]\s*)*(?=\r?\n\s*(?:[#*]|\S|$)|$)/gi,
+    (match, offset, fullText) => {
+      const rest = fullText.slice(offset + match.length);
+      const nextSectionIndex = rest.search(/\n\s*(?:#|\*\*)/);
+      const segment = nextSectionIndex !== -1 ? rest.slice(0, nextSectionIndex) : rest;
+      if (!/^\s*[-*+]\s+\S/m.test(segment)) {
+        return '';
+      }
+      return match;
+    },
+  );
+
+  // 8. Restore protected code blocks in reverse order
+  for (let i = placeholders.length - 1; i >= 0; i--) {
+    const { id, content: blockContent } = placeholders[i];
+    cleaned = cleaned.replace(id, () => blockContent);
   }
 
-  // 8. Normalize spacing: collapse 3+ newlines to 2, trim
+  // 9. Normalize spacing: collapse 3+ newlines to 2, trim
   cleaned = cleaned.replace(/[ \t]+$/gm, '');
   cleaned = cleaned.replace(/\n{3,}/g, '\n\n').trim();
 

--- a/content/utils/strip-images.js
+++ b/content/utils/strip-images.js
@@ -1,0 +1,52 @@
+/**
+ * Image Stripping Utility
+ * Thoroughly removes all image formats, leaked image scripts, and inline base64 data.
+ */
+
+/**
+ * Strips images and image data from message content.
+ * @param {string} content - Markdown or text content
+ * @returns {string} Content with images removed
+ */
+export function stripImages(content) {
+  if (!content || typeof content !== 'string') return '';
+
+  let cleaned = content;
+
+  // 1. Remove markdown images: ![alt](url) (using [\\s\\S]*? to handle multi-line base64 URLs)
+  cleaned = cleaned.replace(/!\[[\s\S]*?\]\([\s\S]*?\)/g, '');
+
+  // 2. Remove HTML img tags: <img ... /> or <img ...>
+  cleaned = cleaned.replace(/<img\b[\s\S]*?\/?>/gi, '');
+
+  // 3. Remove leaked Google Search AI / SGE image injection scripts:
+  // e.g. sn._setImageSrc('...', 'data:image...') or sn.\_setImageSrc(...)
+  cleaned = cleaned.replace(/(?:google\.)?(?:sn\.)?\\?_setImageSrc\s*\([\s\S]*?\);?/gi, '');
+
+  // 4. Remove standalone base64 data URIs (delimited by boundary, quotes, or whitespace)
+  cleaned = cleaned.replace(
+    /data:image(?:\/|\\\/)[a-zA-Z0-9+.-]+;base64,[A-Za-z0-9+/=]+(?:={0,2})/gi,
+    '',
+  );
+
+  // 5. Remove empty list items left behind by stripped images (e.g., "- " or "* " alone on a line)
+  cleaned = cleaned.replace(/^\s*[-*+]\s*$/gm, '');
+
+  // 6. Clean up ChatGPT style "**Images:**" header if left empty
+  cleaned = cleaned.replace(/\*\*Images:\*\*\s*(?=\*\*|$)/gi, '');
+
+  // 7. Clean up ChatGPT style "**Attachments & Images:**" section if it has no items left
+  const attachmentSectionIndex = cleaned.indexOf('**Attachments & Images:**');
+  if (attachmentSectionIndex !== -1) {
+    const afterHeader = cleaned.slice(attachmentSectionIndex + '**Attachments & Images:**'.length);
+    if (!/- \S/g.test(afterHeader)) {
+      cleaned = cleaned.slice(0, attachmentSectionIndex);
+    }
+  }
+
+  // 8. Normalize spacing: collapse 3+ newlines to 2, trim
+  cleaned = cleaned.replace(/[ \t]+$/gm, '');
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n').trim();
+
+  return cleaned;
+}

--- a/entrypoints/content.js
+++ b/entrypoints/content.js
@@ -30,6 +30,7 @@ import {
   resolveConversationTitle,
   DEFAULT_FILENAME_TEMPLATE,
 } from '../content/utils/filename.js';
+import { stripImages } from '../content/utils/strip-images.js';
 import { createLogger } from '../content/utils/logger.js';
 
 const logger = createLogger('ContentScript');
@@ -150,24 +151,6 @@ export default defineContentScript({
           (document.head || document.documentElement).appendChild(s);
         });
       }
-    }
-
-    function stripImages(content) {
-      if (!content) return '';
-      let cleaned = content.replace(/!\[.*?\]\(.*?\)/g, '');
-      cleaned = cleaned.replace(/^\s*[-*+]\s*$/gm, '');
-      cleaned = cleaned.replace(/\*\*Images:\*\*\s*(?=\*\*|$)/gi, '');
-      const attachmentSectionIndex = cleaned.indexOf('**Attachments & Images:**');
-      if (attachmentSectionIndex !== -1) {
-        const afterHeader = cleaned.slice(
-          attachmentSectionIndex + '**Attachments & Images:**'.length,
-        );
-        if (!/- \S/g.test(afterHeader)) {
-          cleaned = cleaned.slice(0, attachmentSectionIndex);
-        }
-      }
-      cleaned = cleaned.replace(/\n{3,}/g, '\n\n').trim();
-      return cleaned;
     }
 
     let activeParser = null;

--- a/entrypoints/preview/index.html
+++ b/entrypoints/preview/index.html
@@ -107,6 +107,13 @@
             </select>
           </div>
 
+          <div class="image-control-group">
+            <label class="checkbox-label" style="margin: 0; cursor: pointer">
+              <input type="checkbox" id="include-images-checkbox" checked />
+              <span data-i18n="includeImages">Include Images</span>
+            </label>
+          </div>
+
           <div class="transfer-control-group">
             <span class="transfer-label" data-i18n="continueOn">Continue On:</span>
             <select
@@ -171,10 +178,6 @@
           <label class="checkbox-label">
             <input type="checkbox" id="png-quality-checkbox" checked />
             <span data-i18n="highQualityPng">High Quality PNG (2x)</span>
-          </label>
-          <label class="checkbox-label">
-            <input type="checkbox" id="include-images-checkbox" checked />
-            <span data-i18n="includeImages">Include Images</span>
           </label>
         </div>
       </header>

--- a/entrypoints/preview/preview.css
+++ b/entrypoints/preview/preview.css
@@ -414,13 +414,14 @@ h1 {
 }
 
 .theme-control-group,
-.transfer-control-group {
+.transfer-control-group,
+.image-control-group {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   background-color: var(--secondary-bg);
   border: 1px solid var(--border-color);
-  padding: 3px;
+  padding: 3px 8px;
   border-radius: 8px;
 }
 

--- a/entrypoints/preview/preview.js
+++ b/entrypoints/preview/preview.js
@@ -7,6 +7,7 @@ import {
   ContinuationFormatter,
   stripEncodedImages,
 } from '../../content/formatters/continuation.js';
+import { stripImages } from '../../content/utils/strip-images.js';
 import { sanitizeHtml } from '../../content/utils/sanitizer.js';
 import { initI18n, applyI18n, t } from '../../content/utils/i18n.js';
 import {
@@ -73,6 +74,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (includeImagesCheckbox) {
     includeImagesCheckbox.addEventListener('change', () => {
       cachedPngBlob = null;
+      recalculateContent();
     });
   }
 
@@ -420,7 +422,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   const recalculateContent = () => {
     if (!conversation || !Array.isArray(conversation.messages)) return;
 
-    const filteredMessages = conversation.messages.filter((_, idx) => selectedIndices.has(idx));
+    const includeImages = includeImagesCheckbox ? includeImagesCheckbox.checked : true;
+    const filteredMessages = conversation.messages
+      .filter((_, idx) => selectedIndices.has(idx))
+      .map((msg) => {
+        if (!includeImages && msg.content) {
+          return { ...msg, content: stripImages(msg.content) };
+        }
+        return msg;
+      });
     const activeConv = { ...conversation, messages: filteredMessages };
 
     const shouldIncludeToc = Boolean(includeTocCheckbox && includeTocCheckbox.checked);
@@ -730,10 +740,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.title = `${effectiveFilename} - Chat Export Preview`;
 
     if (conversation) {
-      htmlContent = htmlFormatter.format(conversation, { theme: currentSyncTheme });
-      markdownContent = markdownFormatter.format(conversation);
-      jsonContent = jsonFormatter.format(conversation);
-      docContent = docFormatter.format(conversation);
+      const includeImages = includeImagesCheckbox ? includeImagesCheckbox.checked : true;
+      const initialMessages = conversation.messages.map((msg) => {
+        if (!includeImages && msg.content) {
+          return { ...msg, content: stripImages(msg.content) };
+        }
+        return msg;
+      });
+      const initialConv = { ...conversation, messages: initialMessages };
+      htmlContent = htmlFormatter.format(initialConv, { theme: currentSyncTheme });
+      markdownContent = markdownFormatter.format(initialConv);
+      jsonContent = jsonFormatter.format(initialConv);
+      docContent = docFormatter.format(initialConv);
     } else {
       const fallbackContent = data.previewContent || '';
       htmlContent = sanitizeHtml(fallbackContent);

--- a/tests/html-formatter.test.mjs
+++ b/tests/html-formatter.test.mjs
@@ -307,7 +307,6 @@ test('HTML formatter resolves reference-style images with bottom definitions', a
       },
     ],
   };
-
   const output = formatter.format(conversation);
 
   assert.ok(
@@ -317,4 +316,43 @@ test('HTML formatter resolves reference-style images with bottom definitions', a
   );
   // Definition lines should not appear as raw text
   assert.ok(!output.includes('[image-1]: data:image'));
+});
+
+test('HTML formatter sanitizes and escapes malicious reference URLs to prevent attribute injection', async () => {
+  const { HtmlFormatter, sanitizeUrl } = await importFormatter();
+  const formatter = new HtmlFormatter();
+
+  // Test sanitizeUrl unit logic
+  assert.equal(sanitizeUrl('javascript:alert(1)', false), '');
+  assert.equal(sanitizeUrl('javascript:alert(1)', true), '');
+  assert.equal(sanitizeUrl('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==', true), '');
+  assert.equal(
+    sanitizeUrl('https://example.com/img.png" onerror="alert(1)', true),
+    'https://example.com/img.png&quot; onerror=&quot;alert(1)',
+  );
+
+  const conversation = {
+    title: 'Security Injection Test',
+    messages: [
+      {
+        role: 'Assistant',
+        content: [
+          '[Click me][xss-link]',
+          '',
+          '![Image XSS][xss-img]',
+          '',
+          '[xss-link]: javascript:alert(document.domain)',
+          '[xss-img]: https://example.com/pic.png"onerror="alert(1)',
+        ].join('\n'),
+      },
+    ],
+  };
+
+  const output = formatter.format(conversation);
+
+  // javascript: link must not be rendered as an active href link
+  assert.ok(!output.includes('href="javascript:'));
+  // attribute injection quotes must be escaped as &quot;
+  assert.ok(!output.includes('onerror="alert(1)"'));
+  assert.ok(output.includes('&quot;onerror=&quot;'));
 });

--- a/tests/html-formatter.test.mjs
+++ b/tests/html-formatter.test.mjs
@@ -292,3 +292,29 @@ test('HTML formatter preserves multi-line user inputs and paragraph line breaks 
   assert.ok(output.includes('<p>this<br>\nis<br>\na<br>\nsentence</p>'));
   assert.ok(output.includes('<p>Second paragraph line 1<br>\nSecond paragraph line 2</p>'));
 });
+
+test('HTML formatter resolves reference-style images with bottom definitions', async () => {
+  const { HtmlFormatter } = await importFormatter();
+  const formatter = new HtmlFormatter();
+
+  const conversation = {
+    title: 'Reference Images Test',
+    messages: [
+      {
+        role: 'Assistant',
+        content:
+          'Here is a diagram:\n\n![my diagram][image-1]\n\n<!-- Image References -->\n\n[image-1]: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      },
+    ],
+  };
+
+  const output = formatter.format(conversation);
+
+  assert.ok(
+    output.includes(
+      '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" alt="my diagram"',
+    ),
+  );
+  // Definition lines should not appear as raw text
+  assert.ok(!output.includes('[image-1]: data:image'));
+});

--- a/tests/markdown-formatter.test.mjs
+++ b/tests/markdown-formatter.test.mjs
@@ -140,3 +140,39 @@ test('MarkdownFormatter preserves math formulas with brackets and does not split
   assert.ok(output.includes('$\\beta = \\rho \\cdot \\frac{\\sigma_a}{\\sigma_m}$'));
   assert.ok(!output.includes('\\\\beta'));
 });
+
+test('MarkdownFormatter converts inline base64 images to reference definitions at the bottom while keeping web URLs inline', () => {
+  const formatter = new MarkdownFormatter();
+
+  const conversation = {
+    title: 'Image Reference Test',
+    messages: [
+      {
+        role: 'User',
+        content:
+          'Check this diagram:\n![diagram](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==)\nand this web link:\n![web logo](https://example.com/logo.png)',
+      },
+      {
+        role: 'Assistant',
+        content:
+          'Here is another one:\n![chart](data:image\\/jpeg;base64,\\/9j\\/4AAQSkZJRgABAQEASABIAAD)',
+      },
+    ],
+  };
+
+  const output = formatter.format(conversation);
+
+  // Markdown body should contain reference links
+  assert.ok(output.includes('![diagram][image-1]'));
+  assert.ok(output.includes('![chart][image-2]'));
+  // Web image should remain inline
+  assert.ok(output.includes('![web logo](https://example.com/logo.png)'));
+  // Base64 definitions should be at the bottom under <!-- Image References -->
+  assert.ok(output.includes('<!-- Image References -->'));
+  assert.ok(
+    output.includes(
+      '[image-1]: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    ),
+  );
+  assert.ok(output.includes('[image-2]: data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD'));
+});

--- a/tests/markdown-formatter.test.mjs
+++ b/tests/markdown-formatter.test.mjs
@@ -176,3 +176,25 @@ test('MarkdownFormatter converts inline base64 images to reference definitions a
   );
   assert.ok(output.includes('[image-2]: data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD'));
 });
+
+test('MarkdownFormatter avoids colliding with pre-existing reference labels in conversation', () => {
+  const formatter = new MarkdownFormatter();
+
+  const conversation = {
+    title: 'Reference Collision Test',
+    messages: [
+      {
+        role: 'User',
+        content:
+          'Existing ref: [image-1]: https://example.com/existing.png\n\n![existing][image-1]\n\nNow an inline base64:\n![new](data:image/png;base64,ABCDEF123456)',
+      },
+    ],
+  };
+
+  const output = formatter.format(conversation);
+
+  // Since [image-1] was already defined in the conversation, the new base64 image should get [image-2]
+  assert.ok(output.includes('![new][image-2]'));
+  assert.ok(output.includes('[image-2]: data:image/png;base64,ABCDEF123456'));
+  assert.ok(output.includes('[image-1]: https://example.com/existing.png'));
+});

--- a/tests/preview-page.test.js
+++ b/tests/preview-page.test.js
@@ -87,3 +87,10 @@ test('preview script contextually toggles copy button on png, pdf, and doc tabs'
     /if\s*\(\s*tabName === 'png' \|\| tabName === 'pdf' \|\| tabName === 'doc'\s*\)/,
   );
 });
+
+test('preview page has global include-images control and recalculates content on toggle', () => {
+  assert.match(previewHtml, /class="[^"]*image-control-group[^"]*"/);
+  assert.match(previewJs, /recalculateContent/);
+  assert.match(previewJs, /stripImages/);
+  assert.match(previewJs, /includeImagesCheckbox\.addEventListener\('change'/);
+});

--- a/tests/strip-images.test.mjs
+++ b/tests/strip-images.test.mjs
@@ -154,3 +154,16 @@ test('stripImages preserves reference definitions if shared by an ordinary text 
   assert.match(output, /\[Documentation\]\[shared\]/);
   assert.match(output, /\[shared\]: https:\/\/example\.com\/shared-resource/);
 });
+
+test('stripImages preserves definitions when image shares with the second of adjacent text links', () => {
+  const input = [
+    'Check ![logo][shared2] and visit [First][first][Second][shared2].',
+    '',
+    '[first]: https://example.com/first',
+    '[shared2]: https://example.com/shared2',
+  ].join('\n');
+  const output = stripImages(input);
+  assert.doesNotMatch(output, /!\[logo\]/);
+  assert.match(output, /\[First\]\[first\]\[Second\]\[shared2\]/);
+  assert.match(output, /\[shared2\]: https:\/\/example\.com\/shared2/);
+});

--- a/tests/strip-images.test.mjs
+++ b/tests/strip-images.test.mjs
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { stripImages } from '../content/utils/strip-images.js';
+
+test('stripImages removes standard markdown images', () => {
+  const input = 'Here is a chart:\n\n![Chart](https://example.com/chart.png)\n\nEnd of response.';
+  const output = stripImages(input);
+  assert.equal(output, 'Here is a chart:\n\nEnd of response.');
+});
+
+test('stripImages removes HTML img tags', () => {
+  const input =
+    'First line<img src="https://example.com/img.jpg" alt="test" />\n\n<img src="/local.png">Second line';
+  const output = stripImages(input);
+  assert.equal(output, 'First line\n\nSecond line');
+});
+
+test('stripImages removes leaked Google Search AI sn._setImageSrc calls with base64 data', () => {
+  const input =
+    "In this setup, your files live safely on Google Drive.[](https://forum.rclone.org/t/123)sn._setImageSrc('img-1','data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAMAAAD04JH5AAAA==')\n\nNext section";
+  const output = stripImages(input);
+  assert.equal(
+    output,
+    'In this setup, your files live safely on Google Drive.[](https://forum.rclone.org/t/123)\n\nNext section',
+  );
+  assert.doesNotMatch(output, /_setImageSrc/);
+  assert.doesNotMatch(output, /data:image/);
+});
+
+test('stripImages removes escaped sn.\\_setImageSrc calls from markdown', () => {
+  const input =
+    "Drive mounted.[](https://example.com)sn.\\_setImageSrc('img-2','data:image\\/png;base64,ABCDEF1234567890==')\n\nDone.";
+  const output = stripImages(input);
+  assert.equal(output, 'Drive mounted.[](https://example.com)\n\nDone.');
+  assert.doesNotMatch(output, /_setImageSrc/);
+  assert.doesNotMatch(output, /data:image/);
+});
+
+test('stripImages removes standalone base64 data URIs', () => {
+  const input =
+    'Raw data: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=\n\nText continues';
+  const output = stripImages(input);
+  assert.equal(output, 'Raw data:\n\nText continues');
+});
+
+test('stripImages cleans empty bullet points and attachment headers', () => {
+  const input = [
+    'Message text',
+    '',
+    '**Attachments & Images:**',
+    '**Images:**',
+    '- ![Alt](https://example.com/pic.png)',
+    '',
+  ].join('\n');
+  const output = stripImages(input);
+  assert.equal(output, 'Message text');
+});
+
+test('stripImages preserves non-image markdown links and formatting', () => {
+  const input =
+    'Check out [Documentation](https://example.com/docs) and **bold text** with `code`.';
+  const output = stripImages(input);
+  assert.equal(output, input);
+});
+
+test('stripImages removes multiline base64 encoded markdown images', () => {
+  const input = [
+    'Before image',
+    '![Large Diagram](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk',
+    '+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==)',
+    'After image',
+  ].join('\n');
+  const output = stripImages(input);
+  assert.equal(output, 'Before image\n\nAfter image');
+  assert.doesNotMatch(output, /data:image/);
+});
+
+test('stripImages removes standalone data URIs with escaped slashes', () => {
+  const input =
+    'Content: data:image\\/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////\n\nFollowing text.';
+  const output = stripImages(input);
+  assert.equal(output, 'Content:\n\nFollowing text.');
+  assert.doesNotMatch(output, /data:image/);
+});

--- a/tests/strip-images.test.mjs
+++ b/tests/strip-images.test.mjs
@@ -82,3 +82,63 @@ test('stripImages removes standalone data URIs with escaped slashes', () => {
   assert.equal(output, 'Content:\n\nFollowing text.');
   assert.doesNotMatch(output, /data:image/);
 });
+
+test('stripImages preserves markdown images inside inline code and fenced code blocks', () => {
+  const input = [
+    'Here is an example in code: `![alt](https://example.com/demo.png)`',
+    '',
+    '```markdown',
+    '![fenced](https://example.com/fenced.png)',
+    '```',
+    '',
+    'And an actual image: ![actual](https://example.com/real.png)',
+  ].join('\n');
+  const output = stripImages(input);
+  assert.match(output, /`!\[alt\]\(https:\/\/example\.com\/demo\.png\)`/);
+  assert.match(output, /!\[fenced\]\(https:\/\/example\.com\/fenced\.png\)/);
+  assert.doesNotMatch(output, /!\[actual\]/);
+});
+
+test('stripImages removes reference-style images and their matching definitions', () => {
+  const input = [
+    'Overview text',
+    '',
+    '![Diagram][image-1]',
+    '![Remote][remote-img]',
+    '',
+    '[image-1]: data:image/png;base64,iVBORw0KGgoAAA==',
+    '[remote-img]: https://example.com/remote.png "Remote Title"',
+    '[regular-link]: https://example.com/page',
+    '',
+    'Conclusion text',
+  ].join('\n');
+  const output = stripImages(input);
+  assert.doesNotMatch(output, /!\[Diagram\]/);
+  assert.doesNotMatch(output, /!\[Remote\]/);
+  assert.doesNotMatch(output, /\[image-1\]:/);
+  assert.doesNotMatch(output, /\[remote-img\]:/);
+  assert.match(output, /\[regular-link\]: https:\/\/example\.com\/page/);
+  assert.match(
+    output,
+    /Overview text\n\n\[regular-link\]: https:\/\/example\.com\/page\n\nConclusion text/,
+  );
+});
+
+test('stripImages preserves content following an empty attachments section', () => {
+  const input = [
+    'First section',
+    '',
+    '**Attachments & Images:**',
+    '- ![Photo](https://example.com/photo.png)',
+    '',
+    '## Next Section',
+    '',
+    'Important text that must be preserved.',
+  ].join('\n');
+  const output = stripImages(input);
+  assert.doesNotMatch(output, /\*\*Attachments & Images:\*\*/);
+  assert.match(
+    output,
+    /First section\n\n## Next Section\n\nImportant text that must be preserved\./,
+  );
+});

--- a/tests/strip-images.test.mjs
+++ b/tests/strip-images.test.mjs
@@ -142,3 +142,15 @@ test('stripImages preserves content following an empty attachments section', () 
     /First section\n\n## Next Section\n\nImportant text that must be preserved\./,
   );
 });
+
+test('stripImages preserves reference definitions if shared by an ordinary text link', () => {
+  const input = [
+    'Check ![logo][shared] and also read [Documentation][shared].',
+    '',
+    '[shared]: https://example.com/shared-resource',
+  ].join('\n');
+  const output = stripImages(input);
+  assert.doesNotMatch(output, /!\[logo\]/);
+  assert.match(output, /\[Documentation\]\[shared\]/);
+  assert.match(output, /\[shared\]: https:\/\/example\.com\/shared-resource/);
+});


### PR DESCRIPTION
## Summary
1. **Markdown Export Base64 Reference Definitions:**
   - In `content/formatters/markdown.js`, transforms inline base64 images into CommonMark reference syntax (`![alt][image-N]`) and appends definitions under `<!-- Image References -->` at the bottom of the exported document.
   - Preserves regular web images (`https://...`) inline.
2. **HTML Export Reference Resolution:**
   - In `content/formatters/html.js`, extracts bottom reference definitions and resolves reference-style images/links into HTML elements.
3. **Preview Page Global Image Toggle:**
   - In `entrypoints/preview/index.html` & `preview.css`, moved the **Include Images** checkbox from the PNG options bar into the main header toolbar, visible across all preview tabs.
   - In `entrypoints/preview/preview.js`, recalculates content across Markdown, HTML Live, HTML Source, JSON, and Word (.doc) formats immediately when toggling.
4. **Shared Robust Image Stripper:**
   - In `content/utils/strip-images.js`, purges markdown images, HTML `<img>`, leaked Google Search AI script blocks (`_setImageSrc`), standalone base64 URIs, and dangling bullet headers.
   - Replaced inline stripper in `entrypoints/content.js`.
5. **Tests:**
   - Added unit tests in `markdown-formatter.test.mjs`, `html-formatter.test.mjs`, `preview-page.test.js`, and `strip-images.test.mjs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reference-style image support, including definitions placed at the end of Markdown content.
  - Base64 images are converted into compact Markdown references without label collisions.
  - Added a preview toolbar option to include or exclude images, with immediate output updates.

- **Bug Fixes**
  - Prevented image definitions from appearing as visible HTML text.
  - Blocked unsafe link and image URLs.
  - Image removal now preserves code content and surrounding text.

- **Tests**
  - Added coverage for image conversion, security, removal, reference resolution, and preview controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->