### PR TITLE
docs: revamp README and prune unsupported transfer targets from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,113 @@
+<div align="center">
+
 # AI Chat Exporter
 
-A simple, privacy-focused browser extension to export AI chats from ChatGPT, Claude, Gemini, Google Search AI, Google Cloud Assist, Google AI Studio, Microsoft Copilot, NotebookLM, Perplexity, DeepSeek, Meta AI, Qwen, Mistral, Proton Lumo, Z.ai, Joyland, and Chub AI to Markdown, JSON, HTML, PDF, Microsoft Word (.doc), or PNG image.
+**Export, back up, and transfer AI conversations to Markdown, JSON, HTML, Word (.doc), and PNG — 100% locally.**
 
-### Quick Install
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/cgakhbhkplndjjknhgegfcipffflcaoj?label=Chrome%20Web%20Store&color=blue)](https://chromewebstore.google.com/detail/ai-chat-exporter-free-pri/cgakhbhkplndjjknhgegfcipffflcaoj)
+[![Firefox Add-ons](https://img.shields.io/amo/v/ai-chat-export?label=Firefox%20Add-ons&color=orange)](https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/)
+[![Microsoft Edge](https://img.shields.io/github/package-json/v/Covai-Labs/ai-chat-exporter?label=Microsoft%20Edge&logo=microsoft-edge&logoColor=white&color=0078D7)](https://microsoftedge.microsoft.com/addons/detail/ai-chat-exporter-free-/hbgckjgfhnaedlihmkogenclfcnobicg)
+
+[![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](LICENSE)
+
+[![Website](https://img.shields.io/badge/Website-ai--chat--exporter.covai.org-blueviolet)](https://ai-chat-exporter.covai.org/)
+
+[Quick Install](#-quick-install) • [Supported Platforms](#-supported-platforms) • [Features](#-key-features) • [Local Development](#-local-development)
+
+---
+
+[![Watch Demo Video](https://img.youtube.com/vi/5V2EZqDkUnU/maxresdefault.jpg)](https://www.youtube.com/watch?v=5V2EZqDkUnU)
+
+<sub>▶️ **Click to watch:** 1-minute walkthrough of chat continuation, selective export, preview themes, and PNG downloads.</sub>
+
+</div>
+
+---
+
+## 🔒 Why AI Chat Exporter? (Privacy First)
+
+Most AI exporters and extensions send your chat history or API calls to third-party backend servers for conversion.
+
+**AI Chat Exporter is 100% local:**
+
+- **Zero Remote Processing:** All DOM extraction, markdown generation, LaTeX parsing, and image rendering occur entirely inside your local browser.
+- **Zero Telemetry / Zero Tracking:** No analytics, no trackers, no external logging, and no remote dependencies.
+- **Your Data Remains Yours:** Chat threads, custom instructions, and exported files never leave your machine.
+
+---
+
+## ✨ Key Features
+
+- **📝 Clean Markdown with Math & Code:**
+  - Preserves syntax highlighting, code languages, tables, and nested lists.
+  - Standardizes LaTeX math formatting (`$$...$$` block and `$...$` inline) without broken backslashes. Ready for **Obsidian**, **Logseq**, and **Notion**.
+- **🔄 Cross-Model Chat Continuation:**
+  - Hand off active conversations between platforms in a single click (e.g., take a ChatGPT conversation and continue it directly in Claude or Gemini).
+- **📓 Direct PKM App Transfer:**
+  - Export straight into **Obsidian** via `obsidian://new` URIs, or trigger URL schemes for **Logseq**, **Bear**, **Drafts**, and **NotePlan**.
+- **🗂️ Standardized JSON Schema:**
+  - Emits structured, normalized chat objects adhering to [Export Schema v1](schemas/export-v1.schema.json) for archiving, backups, and programmatic AI workflows.
+- **📸 Built-in Live Preview & Themes:**
+  - Interactive preview window supporting Dark, Light, and Solarized themes before downloading.
+  - Export high-resolution PNG snapshots of conversations or selective turns.
+- **📋 Smart Dual-MIME Copy:**
+  - One-click copy that places both clean Markdown and rich HTML on your clipboard simultaneously for seamless pasting into emails, Google Docs, or Word.
+- **📄 Word (.doc) & PDF Support:**
+  - Export formatted Word-compatible documents or print-ready PDF files with complete math rendering.
+- **⚡ Chromium Side Panel Support:**
+  - View exports, preview documents, and trigger continuation straight from the native browser side panel without leaving your active tab.
+
+---
+
+## 🌐 Supported Platforms
+
+AI Chat Exporter extracts full conversation threads from all major AI chat platforms, AI search overviews, and web articles. Context continuation allows you to hand off conversations directly to leading LLMs and PKM note-taking apps.
+
+| Platform                                                      | Markdown | JSON | HTML / Doc / PNG | Continuation Target |
+| :------------------------------------------------------------ | :------: | :--: | :--------------: | :-----------------: |
+| **[ChatGPT](https://chatgpt.com)**                            |    ✅    |  ✅  |        ✅        |         ✅          |
+| **[Claude](https://claude.ai)**                               |    ✅    |  ✅  |        ✅        |         ✅          |
+| **[Google Gemini](https://gemini.google.com)**                |    ✅    |  ✅  |        ✅        |         ✅          |
+| **[DeepSeek](https://chat.deepseek.com)**                     |    ✅    |  ✅  |        ✅        |         ✅          |
+| **[Microsoft Copilot](https://copilot.microsoft.com)**        |    ✅    |  ✅  |        ✅        |         ✅          |
+| **[Perplexity](https://www.perplexity.ai)**                   |    ✅    |  ✅  |        ✅        |         ✅          |
+| **[Qwen](https://chat.qwenlm.ai)**                            |    ✅    |  ✅  |        ✅        |         ✅          |
+| **[Mistral / Le Chat](https://chat.mistral.ai)**              |    ✅    |  ✅  |        ✅        |         ✅          |
+| **[Google Search AI (AI Overviews)](https://www.google.com)** |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| **[Google AI Studio](https://aistudio.google.com)**           |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| **[Google Cloud Assist](https://console.cloud.google.com)**   |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| **[NotebookLM](https://notebooklm.google.com)**               |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| **[Meta AI](https://www.meta.ai)**                            |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| **[Proton Lumo](https://lumo.proton.me)**                     |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| **[Z.ai](https://z.ai)**                                      |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| **[Joyland](https://www.joyland.ai)**                         |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| **[Chub AI](https://chub.ai)**                                |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| **Generic Web Articles**                                      |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+
+> **Continuation Targets:** Seamless prompt injection is supported for general-purpose chat models (ChatGPT, Claude, Gemini, DeepSeek, Copilot, Perplexity, Qwen, Mistral) and PKM note-taking apps (**Obsidian**, **Logseq**, **Bear**, **NotePlan**, **Drafts**). Platforms requiring character selection (Joyland, Chub AI) or workspace setup (NotebookLM) are supported for clean export only.
+
+---
+
+## 🚀 Quick Install
+
+### Official Stores
 
 - 🦊 **Firefox**: [Install from Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/)
-- 🌐 **Chrome**: [Install from Chrome Web Store](https://chrome.google.com/webstore/detail/cgakhbhkplndjjknhgegfcipffflcaoj)
+- 🌐 **Chrome / Brave**: [Install from Chrome Web Store](https://chromewebstore.google.com/detail/ai-chat-exporter-free-pri/cgakhbhkplndjjknhgegfcipffflcaoj)
+- 🌊 **Microsoft Edge**: [Install from Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/ai-chat-exporter-free-/hbgckjgfhnaedlihmkogenclfcnobicg)
 
 > [!NOTE]
-> Extension updates on Chrome Web Store may lag behind Firefox / GitHub releases due to long store review queues.
+> Chrome Web Store updates may occasionally lag behind Firefox and GitHub releases due to store review queues.
 
 <details>
 <summary><b>📦 Manual / Unpacked Installation</b></summary>
 
-#### Chrome / Edge / Chromium
+#### Chrome / Edge / Brave / Chromium
 
 1. Download the latest `ai-chat-exporter-chromium.zip` from the [Releases page](https://github.com/Covai-Labs/ai-chat-exporter/releases).
 2. Extract the zip file to a folder on your computer.
 3. Open your browser and navigate to `chrome://extensions/` (or `edge://extensions/`).
-4. Enable **Developer mode** using the toggle switch.
+4. Enable **Developer mode** using the toggle switch in the top-right corner.
 5. Click **Load unpacked** and select the extracted folder.
 
 #### Firefox
@@ -31,83 +120,63 @@ A simple, privacy-focused browser extension to export AI chats from ChatGPT, Cla
 
 </details>
 
-[![AI Chat Exporter Preview](docs/images/screenshot1_export.png)](https://www.youtube.com/watch?v=5V2EZqDkUnU)
+---
 
-> 📺 **Video Walkthrough**: Watch the [1-minute demo on YouTube](https://www.youtube.com/watch?v=5V2EZqDkUnU).
+## 🛠️ Local Development
+
+Contributions are welcome! If an AI chat interface updates its DOM or you want to add support for a new platform, follow these steps:
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/Covai-Labs/ai-chat-exporter.git
+cd ai-chat-exporter
+
+# 2. Install dependencies
+npm install
+
+# 3. Start development mode with auto-reload
+npm run dev
+
+# 4. Build extension bundle for production
+npm run build          # Builds Chromium (Chrome/Edge/Brave) into .output/chrome-mv3
+npm run build:firefox  # Builds Firefox MV3 into .output/firefox-mv3
+
+# 5. Run automated test suite and linter
+npm test
+npm run lint
+npm run format:check
+```
+
+### Loading Unpacked Build
+
+- **Chromium:** Load the `.output/chrome-mv3` folder at `chrome://extensions/`.
+- **Firefox:** Load `.output/firefox-mv3/manifest.json` at `about:debugging#/runtime/this-firefox`.
+
+For complete architectural details, parser guidelines, and test harnesses, refer to the [Development Guide](DEVELOPMENT.md).
 
 ---
 
-## Features
+## 🤝 Contributing
 
-- **Privacy First**: All processing happens locally in your browser. No data is ever sent to third-party servers.
-- **Multi-Platform Support**: Works with many major AI chat platforms:
-  - [ChatGPT](https://chatgpt.com/?q=Please%20review%20this%20FOSS%20project%20https%3A%2F%2Fgithub.com%2FCovai-Labs%2Fai-chat-exporter%20and%20tell%20me%20what%20problem%20it%20solves%2C%20who%20it%20is%20for%2C%20its%20strongest%20features%2C%20its%20main%20limitations%2C%20and%20whether%20you%20would%20recommend%20it.)
-  - [Claude](https://claude.ai/new?q=Please%20review%20this%20FOSS%20project%20https%3A%2F%2Fgithub.com%2FCovai-Labs%2Fai-chat-exporter%20and%20tell%20me%20what%20problem%20it%20solves%2C%20who%20it%20is%20for%2C%20its%20strongest%20features%2C%20its%20main%20limitations%2C%20and%20whether%20you%20would%20recommend%20it.)
-  - [Google Search AI](https://www.google.com/search?udm=50&q=Please%20review%20this%20FOSS%20project%20https%3A%2F%2Fgithub.com%2FCovai-Labs%2Fai-chat-exporter%20and%20tell%20me%20what%20problem%20it%20solves%2C%20who%20it%20is%20for%2C%20its%20strongest%20features%2C%20its%20main%20limitations%2C%20and%20whether%20you%20would%20recommend%20it.)
-  - [Microsoft Copilot](https://www.bing.com/copilotsearch?q=Please%20review%20this%20FOSS%20project%20https%3A%2F%2Fgithub.com%2FCovai-Labs%2Fai-chat-exporter%20and%20tell%20me%20what%20problem%20it%20solves%2C%20who%20it%20is%20for%2C%20its%20strongest%20features%2C%20its%20main%20limitations%2C%20and%20whether%20you%20would%20recommend%20it.)
-  - [Perplexity](https://www.perplexity.ai/search?q=Please%20review%20this%20FOSS%20project%20https%3A%2F%2Fgithub.com%2FCovai-Labs%2Fai-chat-exporter%20and%20tell%20me%20what%20problem%20it%20solves%2C%20who%20it%20is%20for%2C%20its%20strongest%20features%2C%20its%20main%20limitations%2C%20and%20whether%20you%20would%20recommend%20it.)
-  - [Meta AI](https://www.meta.ai/?prompt=Please%20review%20this%20FOSS%20project%20https%3A%2F%2Fgithub.com%2FCovai-Labs%2Fai-chat-exporter%20and%20tell%20me%20what%20problem%20it%20solves%2C%20who%20it%20is%20for%2C%20its%20strongest%20features%2C%20its%20main%20limitations%2C%20and%20whether%20you%20would%20recommend%20it.)
-  - Gemini
-  - Google Cloud Assist
-  - Google AI Studio
-  - NotebookLM
-  - DeepSeek
-  - Qwen
-  - Z.ai
-  - Mistral
-  - Proton Lumo
-  - Joyland
-  - Chub AI
+Platform web layouts evolve frequently. If an exporter encounters issues on a modified layout:
 
-- **Versatile Export Formats**:
-  - **Clean Markdown**: Properly formatted with code blocks, tables, and images preserved.
-  - **Structured JSON**: Normalized JSON exports matching a strict JSON schema.
-  - **Raw HTML**: Complete chat layout with math equations.
-  - **PDF Document**: Print or save chat threads as PDF using browser native print.
-  - **Microsoft Word (.doc)**: Export formatted chat documents ready to open in Microsoft Word.
-  - **Shareable Image (PNG)**: Convert the chat thread into a clean, sharing-ready PNG image using `html2canvas`.
-- **Chat Continuation & Obsidian Transfer**: Move your active chat context directly across platforms (e.g. send your current Claude conversation straight to Gemini, ChatGPT, or open directly in **Obsidian** via `obsidian://new` URIs).
-- **Clipboard Rich-Text Copying**: Instantly copy chats to your clipboard with rich-text formatting, perfect for pasting directly into emails, document editors, or notes.
-- **Side Panel Support (Chromium Only)**: View exports and run chat context continuation inside your browser's native side panel for a streamlined workflow.
-- **Custom Filenames**: Input custom filenames before exporting to keep your downloads structured.
-- **One-Click Export**: Quick popup interface for fast exports.
-
-## Usage
-
-1. Navigate to any supported AI chat platform
-2. Click the AI Chat Exporter icon in your browser toolbar
-3. Choose Markdown or JSON, then click "Export Chat" to download the file
-4. The file is saved to your Downloads folder with a timestamped filename
-
-## Development
-
-For setup, building from source, and details on project structure, please refer to the [Development Guide](DEVELOPMENT.md).
-
-## Privacy
-
-AI Chat Exporter does not collect, store, or transmit any personal data.
-See the full [Privacy Policy](https://ai-chat-exporter.covai.org/privacy.html) for details.
-
-## License
-
-This Source Code Form is subject to the terms of the Mozilla Public License,
-v. 2.0. See [LICENSE](LICENSE) for the full license text.
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit issues or pull requests.
-
-## Acknowledgments
-
-- Uses [Turndown.js](https://github.com/mixmark-io/turndown) for HTML to Markdown conversion.
-- Uses [DOMPurify](https://github.com/cure53/DOMPurify) for HTML content sanitization and security.
-- Uses [html2canvas](https://github.com/niklasvh/html2canvas) for generating shareable PNG image exports.
-- Uses [KaTeX](https://github.com/KaTeX/KaTeX) for rendering math and LaTeX equations.
-- Uses [Prism.js](https://github.com/PrismJS/prism) for code block syntax highlighting.
-- Built with [WXT](https://wxt.dev/) extension development framework.
+1. Check existing [Issues](https://github.com/Covai-Labs/ai-chat-exporter/issues) or open a new one with the platform name and DOM context.
+2. Submit a Pull Request following our [Contribution Guidelines](CONTRIBUTING.md).
 
 ---
 
-> **Nota bene:** This extension was developed for personal use and may not be very polished. I release it with the hope that it can be useful to others. Additionally, formatting of exported items from certain chats may currently not work well due to changes in those chat platforms. You are welcome to submit an issue or PR.
+## 📄 License
 
-_Note: Feedback and issue reports are very welcome — feel free to submit [Feedback / Issue Reports](https://ai-chat-exporter.covai.org/feedback.html) or open a [GitHub Issue](https://github.com/Covai-Labs/ai-chat-exporter/issues)._
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. See [LICENSE](LICENSE) for the full license text.
+
+---
+
+## 🙏 Acknowledgments
+
+- [decant-core](https://github.com/Covai-Labs/decant-core) — Shared parser engine and intelligent article extraction.
+- [Turndown.js](https://github.com/mixmark-io/turndown) — HTML to Markdown conversion.
+- [DOMPurify](https://github.com/cure53/DOMPurify) — HTML sanitization.
+- [html2canvas](https://github.com/niklasvh/html2canvas) — Client-side PNG rendering.
+- [KaTeX](https://github.com/KaTeX/KaTeX) — Math and LaTeX equation rendering.
+- [Prism.js](https://github.com/PrismJS/prism) — Code block syntax highlighting.
+- [WXT](https://wxt.dev/) — Extension development framework.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![Website](https://img.shields.io/badge/Website-ai--chat--exporter.covai.org-blueviolet)](https://ai-chat-exporter.covai.org/)
 
-[Quick Install](#-quick-install) • [Supported Platforms](#-supported-platforms) • [Features](#-key-features) • [Local Development](#-local-development)
+[Quick Install](#quick-install) • [Supported Platforms](#supported-platforms) • [Features](#key-features) • [Local Development](#local-development)
 
 ---
 
@@ -63,28 +63,28 @@ Most AI exporters and extensions send your chat history or API calls to third-pa
 
 AI Chat Exporter extracts full conversation threads from all major AI chat platforms, AI search overviews, and web articles. Context continuation allows you to hand off conversations directly to leading LLMs and PKM note-taking apps.
 
-| Platform                                                      | Markdown | JSON | HTML / Doc / PNG | Continuation Target |
-| :------------------------------------------------------------ | :------: | :--: | :--------------: | :-----------------: |
-| **[ChatGPT](https://chatgpt.com)**                            |    ✅    |  ✅  |        ✅        |         ✅          |
-| **[Claude](https://claude.ai)**                               |    ✅    |  ✅  |        ✅        |         ✅          |
-| **[Google Gemini](https://gemini.google.com)**                |    ✅    |  ✅  |        ✅        |         ✅          |
-| **[DeepSeek](https://chat.deepseek.com)**                     |    ✅    |  ✅  |        ✅        |         ✅          |
-| **[Microsoft Copilot](https://copilot.microsoft.com)**        |    ✅    |  ✅  |        ✅        |         ✅          |
-| **[Perplexity](https://www.perplexity.ai)**                   |    ✅    |  ✅  |        ✅        |         ✅          |
-| **[Qwen](https://chat.qwenlm.ai)**                            |    ✅    |  ✅  |        ✅        |         ✅          |
-| **[Mistral / Le Chat](https://chat.mistral.ai)**              |    ✅    |  ✅  |        ✅        |         ✅          |
-| **[Google Search AI (AI Overviews)](https://www.google.com)** |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
-| **[Google AI Studio](https://aistudio.google.com)**           |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
-| **[Google Cloud Assist](https://console.cloud.google.com)**   |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
-| **[NotebookLM](https://notebooklm.google.com)**               |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
-| **[Meta AI](https://www.meta.ai)**                            |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
-| **[Proton Lumo](https://lumo.proton.me)**                     |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
-| **[Z.ai](https://z.ai)**                                      |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
-| **[Joyland](https://www.joyland.ai)**                         |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
-| **[Chub AI](https://chub.ai)**                                |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
-| **Generic Web Articles**                                      |    ✅    |  ✅  |        ✅        |  — _(Export only)_  |
+| Platform                                                      | Markdown | JSON | HTML / Doc / PNG |    Continuation Target     |
+| :------------------------------------------------------------ | :------: | :--: | :--------------: | :------------------------: |
+| **[ChatGPT](https://chatgpt.com)**                            |    ✅    |  ✅  |        ✅        |             ✅             |
+| **[Claude](https://claude.ai)**                               |    ✅    |  ✅  |        ✅        |             ✅             |
+| **[Google Gemini](https://gemini.google.com)**                |    ✅    |  ✅  |        ✅        |             ✅             |
+| **[DeepSeek](https://chat.deepseek.com)**                     |    ✅    |  ✅  |        ✅        |             ✅             |
+| **[Microsoft Copilot](https://copilot.microsoft.com)**        |    ✅    |  ✅  |        ✅        |     — _(Export only)_      |
+| **[Perplexity](https://www.perplexity.ai)**                   |    ✅    |  ✅  |        ✅        |             ✅             |
+| **[Qwen](https://chat.qwenlm.ai)**                            |    ✅    |  ✅  |        ✅        |             ✅             |
+| **[Mistral / Le Chat](https://chat.mistral.ai)**              |    ✅    |  ✅  |        ✅        |             ✅             |
+| **[Google Search AI (AI Overviews)](https://www.google.com)** |    ✅    |  ✅  |        ✅        |     — _(Export only)_      |
+| **[Google AI Studio](https://aistudio.google.com)**           |    ✅    |  ✅  |        ✅        |     — _(Export only)_      |
+| **[Google Cloud Assist](https://console.cloud.google.com)**   |    ✅    |  ✅  |        ✅        |     — _(Export only)_      |
+| **[NotebookLM](https://notebooklm.google.com)**               |    ✅    |  ✅  |        ✅        | — _(Export audio & notes)_ |
+| **[Meta AI](https://www.meta.ai)**                            |    ✅    |  ✅  |        ✅        |     — _(Export only)_      |
+| **[Proton Lumo](https://lumo.proton.me)**                     |    ✅    |  ✅  |        ✅        |             ✅             |
+| **[Z.ai](https://z.ai)**                                      |    ✅    |  ✅  |        ✅        |     — _(Export only)_      |
+| **[Joyland](https://www.joyland.ai)**                         |    ✅    |  ✅  |        ✅        |     — _(Export only)_      |
+| **[Chub AI](https://chub.ai)**                                |    ✅    |  ✅  |        ✅        |     — _(Export only)_      |
+| **Generic Web Articles**                                      |    ✅    |  ✅  |        ✅        |     — _(Export only)_      |
 
-> **Continuation Targets:** Seamless prompt injection is supported for general-purpose chat models (ChatGPT, Claude, Gemini, DeepSeek, Copilot, Perplexity, Qwen, Mistral) and PKM note-taking apps (**Obsidian**, **Logseq**, **Bear**, **NotePlan**, **Drafts**). Platforms requiring character selection (Joyland, Chub AI) or workspace setup (NotebookLM) are supported for clean export only.
+> **Continuation Targets:** Seamless prompt injection is supported for general-purpose chat models (ChatGPT, Claude, Gemini, DeepSeek, Proton Lumo, Perplexity, Qwen, Mistral) and PKM note-taking apps (**Obsidian**, **Logseq**, **Bear**, **NotePlan**, **Drafts**). Platforms requiring character selection (Joyland, Chub AI) or workspace setup (NotebookLM) are supported for clean export only.
 
 ---
 

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -228,9 +228,6 @@
                 <option value="perplexity">Perplexity (perplexity.ai)</option>
                 <option value="mistral">Mistral (chat.mistral.ai)</option>
                 <option value="lumo">Lumo (lumo.proton.me)</option>
-                <option value="joyland">Joyland (joyland.ai)</option>
-                <option value="chub">Chub AI (chub.ai)</option>
-                <option value="notebooklm">NotebookLM (notebook.google.com)</option>
                 <option value="obsidian">Obsidian (obsidian://)</option>
                 <option value="logseq">Logseq (logseq://)</option>
                 <option value="bear">Bear (bear://)</option>

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -99,9 +99,6 @@
                 <option value="perplexity">Perplexity</option>
                 <option value="mistral">Mistral</option>
                 <option value="lumo">Lumo</option>
-                <option value="joyland">Joyland</option>
-                <option value="chub">Chub AI</option>
-                <option value="notebooklm">NotebookLM</option>
                 <option value="obsidian">Obsidian</option>
                 <option value="logseq">Logseq</option>
                 <option value="bear">Bear</option>

--- a/entrypoints/preview/index.html
+++ b/entrypoints/preview/index.html
@@ -129,9 +129,6 @@
               <option value="qwen">Qwen</option>
               <option value="mistral">Mistral</option>
               <option value="lumo">Lumo</option>
-              <option value="joyland">Joyland</option>
-              <option value="chub">Chub AI</option>
-              <option value="notebooklm">NotebookLM</option>
               <option value="obsidian">Obsidian</option>
               <option value="logseq">Logseq</option>
               <option value="bear">Bear</option>

--- a/options/options.html
+++ b/options/options.html
@@ -228,9 +228,6 @@
                 <option value="perplexity">Perplexity (perplexity.ai)</option>
                 <option value="mistral">Mistral (chat.mistral.ai)</option>
                 <option value="lumo">Lumo (lumo.proton.me)</option>
-                <option value="joyland">Joyland (joyland.ai)</option>
-                <option value="chub">Chub AI (chub.ai)</option>
-                <option value="notebooklm">NotebookLM (notebook.google.com)</option>
                 <option value="obsidian">Obsidian (obsidian://)</option>
                 <option value="logseq">Logseq (logseq://)</option>
                 <option value="bear">Bear (bear://)</option>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -99,9 +99,6 @@
                 <option value="perplexity">Perplexity</option>
                 <option value="mistral">Mistral</option>
                 <option value="lumo">Lumo</option>
-                <option value="joyland">Joyland</option>
-                <option value="chub">Chub AI</option>
-                <option value="notebooklm">NotebookLM</option>
                 <option value="obsidian">Obsidian</option>
                 <option value="logseq">Logseq</option>
                 <option value="bear">Bear</option>

--- a/popup/preview.html
+++ b/popup/preview.html
@@ -95,9 +95,6 @@
               <option value="qwen">Qwen</option>
               <option value="mistral">Mistral</option>
               <option value="lumo">Lumo</option>
-              <option value="joyland">Joyland</option>
-              <option value="chub">Chub AI</option>
-              <option value="notebooklm">NotebookLM</option>
               <option value="obsidian">Obsidian</option>
               <option value="logseq">Logseq</option>
               <option value="bear">Bear</option>


### PR DESCRIPTION
## Summary
- **README Revamp:**
  - Added official store badges for Chrome Web Store, Firefox Add-ons, and Microsoft Edge Add-ons (dynamic version badge).
  - Added clickable high-res YouTube video card linking to the 1-minute walkthrough.
  - Highlighted privacy differentiator (100% local, zero telemetry).
  - Clarified supported platforms table: distinguished full export platforms from valid continuation targets.
  - Streamlined quick install and 5-step local development setup.
- **UI Transfer Dropdown Cleanup:**
  - Removed unsupported transfer targets (`joyland`, `chub`, and `notebooklm`) from popup, preview, and options dropdowns where prompt auto-injection is not supported.
- **Verification:**
  - `npm test` passed all 168 tests.
  - `npm run lint` and `npm run format:check` passed cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded and reorganised the documentation with privacy details, feature descriptions, supported platforms, export capabilities, installation guidance, local development instructions, contribution information, licensing and acknowledgements.

- **Changes**
  - Removed Joyland, Chub AI and NotebookLM from the available transfer-target lists across the options, popup and preview interfaces.
  - All remaining transfer destinations are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->