### PR TITLE
feat(claude): update decant-core to 1.4.0 for interactive elements and unrolled carousels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.15.1",
       "hasInstallScript": true,
       "dependencies": {
-        "decant-core": "^1.2.6",
+        "decant-core": "^1.4.0",
         "dompurify": "^3.4.14",
         "html2canvas": "^1.4.1",
         "katex": "^0.18.5",
@@ -1264,14 +1264,14 @@
       }
     },
     "node_modules/decant-core": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/decant-core/-/decant-core-1.2.6.tgz",
-      "integrity": "sha512-7bmiWlptlft3aB2eG5L4HY3Sx/8sHDQ+K2K8B4oasQeO+ZdAUwRM6ZYWHbic49KnX2D4fxxvis63q5vlYgfuoQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/decant-core/-/decant-core-1.4.0.tgz",
+      "integrity": "sha512-VWz9GwIzyH8u8qNFfAJK54/RaFzaz+2LRP02cbemNNzPs6u8bBDsRVqJvHMWyi35Jx/J/dDk2XmXXp0DwIEKdg==",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@extractus/article-extractor": "^9.0.0",
+        "@extractus/article-extractor": "^9.0.1",
         "@mozilla/readability": "^0.6.0",
-        "defuddle": "^0.19.2",
+        "defuddle": "^0.19.3",
         "turndown": "^7.2.4",
         "turndown-plugin-gfm": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "wxt": "^0.21.4"
   },
   "dependencies": {
-    "decant-core": "^1.2.6",
+    "decant-core": "^1.4.0",
     "dompurify": "^3.4.14",
     "html2canvas": "^1.4.1",
     "katex": "^0.18.5",

--- a/tests/claude-parser.test.mjs
+++ b/tests/claude-parser.test.mjs
@@ -267,9 +267,9 @@ test('ClaudeParser unrolls interactive carousel elements in ai-chat-exporter', a
   const msg = result.messages[0];
   assert.equal(msg.role, 'Claude');
   assert.match(msg.content, /Here are recommendations/);
-  assert.match(msg.content, /1\\\.? First Recommendation/);
+  assert.match(msg.content, /1(\\\.)?\.? First Recommendation/);
   assert.match(msg.content, /Details for step 1/);
-  assert.match(msg.content, /2\\\.? Second Recommendation/);
+  assert.match(msg.content, /2(\\\.)?\.? Second Recommendation/);
   assert.match(msg.content, /Details for step 2/);
   assert.match(msg.content, /Conclusion text/);
   assert.doesNotMatch(msg.content, /Go to step 1/);

--- a/tests/claude-parser.test.mjs
+++ b/tests/claude-parser.test.mjs
@@ -225,3 +225,52 @@ test('ClaudeParser extracts conversation from Claude API when available', async 
   assert.equal(result.messages[3].role, 'User');
   assert.match(result.messages[3].content, /Thank you!/);
 });
+
+test('ClaudeParser unrolls interactive carousel elements in ai-chat-exporter', async () => {
+  const html = `
+    <html>
+      <head><title>Claude Interactive Chat</title></head>
+      <body>
+        <div class="font-claude-response">
+          <p>Here are recommendations:</p>
+          <div class="@container bg-surface-2">
+            <button aria-label="Go to step 1">1</button>
+            <button aria-label="Go to step 2">2</button>
+            <div>
+              <span class="text-title">First Recommendation</span>
+              <span class="text-body">Details for step 1</span>
+            </div>
+            <div class="invisible">
+              <span class="text-title">Second Recommendation</span>
+              <span class="text-body">Details for step 2</span>
+            </div>
+          </div>
+          <p>Conclusion text</p>
+        </div>
+      </body>
+    </html>
+  `;
+  const { window, document, HTMLElement, Node, DOMParser } = parseHTML(html);
+  global.window = window;
+  global.document = document;
+  global.HTMLElement = HTMLElement;
+  global.Node = Node;
+  global.DOMParser = DOMParser;
+  global.chrome = { runtime: { getURL: (path) => path } };
+  global.fetch = async () => ({ ok: false, status: 404 });
+
+  const { ClaudeParser } = await import('decant-core');
+  const parser = new ClaudeParser();
+  const result = await parser.parse({ parserMode: 'prefer_dom' });
+
+  assert.equal(result.messages.length, 1);
+  const msg = result.messages[0];
+  assert.equal(msg.role, 'Claude');
+  assert.match(msg.content, /Here are recommendations/);
+  assert.match(msg.content, /1\\\.? First Recommendation/);
+  assert.match(msg.content, /Details for step 1/);
+  assert.match(msg.content, /2\\\.? Second Recommendation/);
+  assert.match(msg.content, /Details for step 2/);
+  assert.match(msg.content, /Conclusion text/);
+  assert.doesNotMatch(msg.content, /Go to step 1/);
+});


### PR DESCRIPTION
## Summary
Updates `decant-core` to [`1.4.0`](https://www.npmjs.com/package/decant-core/v/1.4.0) to inherit support for Claude's interactive elements:
- Unrolling DOM interactive carousels and multi-step recommendation cards sequentially without button or step indicator noise.
- Extracting and inlining interactive JSX widgets (`visualize:show_widget`).
- Pairing questionnaire tool uses (`AskUserQuestion`) with user responses.
- Folding multi-step artifact update diffs into clean final code blocks.
- Added unit test in `tests/claude-parser.test.mjs` validating interactive carousel unrolling.

## Verification
- `npm test` passed (169/169 tests pass).
- `npm run lint` passed (0 errors).
- `npm run format:check` passed (0 formatting issues).
- `npm run build` (Chrome MV3) succeeded.
- `npm run build:firefox` (Firefox MV3) succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime foundation to support the latest compatible release.
* **Tests**
  * Added coverage for interactive carousel content in Claude conversation exports.
  * Verified that visible and hidden recommendations are extracted in order, surrounding text is preserved, and navigation labels are excluded.
  * Confirmed the parser returns a single correctly structured Claude message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->