### PR TITLE
docs(seo): add 19 intent-specific landing pages for search visibility

### DIFF
--- a/docs/ai-chat-backup.html
+++ b/docs/ai-chat-backup.html
@@ -47,7 +47,7 @@
     <div class="hero">
       <span class="badge">100% Local</span>
       <h1>AI Chat Backup &mdash; Never Lose a Conversation</h1>
-      <p class="hero-subtitle">Back up conversations from ChatGPT, Claude, Gemini and 15 other AI platforms. Structured Markdown, JSON, or PDF. Everything stays on your machine.</p>
+      <p class="hero-subtitle">Back up conversations from ChatGPT, Claude, Gemini and 14 other AI platforms. Structured Markdown, JSON, or PDF. Everything stays on your machine.</p>
       <div class="cta-group">
         <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
         <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
@@ -142,28 +142,24 @@
       <h2>Recommended Backup Workflow</h2>
       <div class="steps">
         <div class="step">
-          <div class="step-number">1</div>
           <div class="step-content">
             <h3>Create a Backup Directory</h3>
             <p>Set up a dedicated folder for your AI conversation backups. A good structure is organized by platform and date: <code>backups/chatgpt/2026/</code>, <code>backups/claude/2026/</code>. This keeps things organized from the start.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">2</div>
           <div class="step-content">
             <h3>Configure Filename Templates</h3>
             <p>AI Chat Exporter supports filename templates that control how exported files are named. A useful backup template is <code>{platform} - {title} - {datetime}</code>. This produces unique, sortable filenames for every export.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">3</div>
           <div class="step-content">
             <h3>Export Important Conversations</h3>
             <p>After completing an important conversation, click the extension icon and export to Markdown (for readability) or JSON (for structured data). For critical conversations, export to both formats. The whole process takes under 5 seconds.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">4</div>
           <div class="step-content">
             <h3>Sync to Cloud Storage (Optional)</h3>
             <p>Since the export files are standard formats stored on your local machine, you can sync them to any cloud storage service (iCloud, Google Drive, Dropbox, Syncthing) using your preferred sync tool. This adds an off-machine backup layer without trusting any third-party backup service with your AI data.</p>
@@ -387,8 +383,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/ai-chat-backup.html
+++ b/docs/ai-chat-backup.html
@@ -152,7 +152,7 @@
           <div class="step-number">2</div>
           <div class="step-content">
             <h3>Configure Filename Templates</h3>
-            <p>AI Chat Exporter supports filename templates that control how exported files are named. A useful backup template is <code>{platform}/{year}-{month}/{title}</code>. This automatically organizes files into platform and date folders.</p>
+            <p>AI Chat Exporter supports filename templates that control how exported files are named. A useful backup template is <code>{platform} - {title} - {datetime}</code>. This produces unique, sortable filenames for every export.</p>
           </div>
         </div>
         <div class="step">
@@ -257,7 +257,7 @@
             <tr>
               <td><code>{datetime}</code></td>
               <td>Export timestamp</td>
-              <td>2026-09-08T14:30:00</td>
+              <td>2026-09-08_14-30</td>
             </tr>
             <tr>
               <td><code>{date}</code></td>
@@ -265,19 +265,19 @@
               <td>2026-09-08</td>
             </tr>
             <tr>
-              <td><code>{year}</code></td>
-              <td>Year</td>
-              <td>2026</td>
+              <td><code>{time}</code></td>
+              <td>Time only</td>
+              <td>14-30</td>
             </tr>
             <tr>
-              <td><code>{month}</code></td>
-              <td>Month</td>
-              <td>09</td>
+              <td><code>{timestamp}</code></td>
+              <td>Date + time</td>
+              <td>2026-09-08_14-30</td>
             </tr>
           </tbody>
         </table>
       </div>
-      <p>A useful backup template is <code>{platform}/{year}-{month}/{title}</code>, which creates platform-specific folders organized by month. This makes it easy to browse your archive and find specific conversations.</p>
+      <p>Since filename separators like <code>/</code> are stripped for filesystem safety, all exports land as flat files. Use the <code>{platform} - {title} - {datetime}</code> template to produce unique, sortable filenames that make it easy to browse and find specific conversations.</p>
     </section>
 
     <section class="content-section">

--- a/docs/ai-chat-backup.html
+++ b/docs/ai-chat-backup.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AI Chat Backup — Save and Archive All Your AI Conversations</title>
-  <meta name="description" content="Back up conversations from ChatGPT, Claude, Gemini and 15+ AI platforms. Structured JSON, Markdown, or PDF. 100% local. Free, open-source." />
+  <meta name="description" content="Back up conversations from ChatGPT, Claude, Gemini and 14 other AI platforms. Structured JSON, Markdown, or PDF. 100% local. Free, open-source." />
   <link rel="canonical" href="https://ai-chat-exporter.covai.org/ai-chat-backup.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://ai-chat-exporter.covai.org/ai-chat-backup.html" />
   <meta property="og:title" content="AI Chat Backup — Save and Archive All Your AI Conversations" />
-  <meta property="og:description" content="Back up conversations from ChatGPT, Claude, Gemini and 15+ AI platforms. Structured JSON, Markdown, or PDF. 100% local. Free, open-source." />
+  <meta property="og:description" content="Back up conversations from ChatGPT, Claude, Gemini and 14 other AI platforms. Structured JSON, Markdown, or PDF. 100% local. Free, open-source." />
   <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
   <meta property="og:site_name" content="AI Chat Exporter" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/docs/ai-chat-backup.html
+++ b/docs/ai-chat-backup.html
@@ -1,0 +1,395 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Chat Backup — Save and Archive All Your AI Conversations</title>
+  <meta name="description" content="Back up conversations from ChatGPT, Claude, Gemini and 15+ AI platforms. Structured JSON, Markdown, or PDF. 100% local. Free, open-source." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/ai-chat-backup.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/ai-chat-backup.html" />
+  <meta property="og:title" content="AI Chat Backup — Save and Archive All Your AI Conversations" />
+  <meta property="og:description" content="Back up conversations from ChatGPT, Claude, Gemini and 15+ AI platforms. Structured JSON, Markdown, or PDF. 100% local. Free, open-source." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>&rsaquo;</span> <span>AI Chat Backup</span></div>
+
+  <main>
+    <div class="hero">
+      <span class="badge">100% Local</span>
+      <h1>AI Chat Backup &mdash; Never Lose a Conversation</h1>
+      <p class="hero-subtitle">Back up conversations from ChatGPT, Claude, Gemini and 15 other AI platforms. Structured Markdown, JSON, or PDF. Everything stays on your machine.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <section class="content-section">
+      <h2>Why Backup AI Conversations?</h2>
+      <p>You use AI platforms every day for work, study, and creative projects. You generate code, draft documents, research topics, brainstorm ideas, and solve problems in conversations that span hours or days. But none of these conversations are truly yours.</p>
+      <p>AI platforms store your data on their servers, and you have limited control over what happens to it. Conversations can be deleted when you clear your history, removed during account issues, or lost during platform changes. OpenAI's data export gives you a single unwieldy JSON archive that is nearly impossible to use. Anthropic offers no bulk export at all. Most smaller platforms offer nothing.</p>
+      <p>A regular backup habit protects your work. If a conversation contains valuable code, important research findings, or creative work you spent hours developing, having a local backup means you never have to worry about losing it.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>The Problem with Built-in Exports</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Platform</th>
+              <th>Built-in Export</th>
+              <th>Quality</th>
+              <th>Usability</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>ChatGPT</strong></td>
+              <td>Settings &gt; Data Export (all conversations)</td>
+              <td>Raw JSON archive, URLs expire</td>
+              <td>Nearly unusable without scripting</td>
+            </tr>
+            <tr>
+              <td><strong>Claude</strong></td>
+              <td>Limited export feature</td>
+              <td>Basic JSON</td>
+              <td>No formatting, no Artifacts</td>
+            </tr>
+            <tr>
+              <td><strong>Gemini</strong></td>
+              <td>Google Takeout</td>
+              <td>JSON with nested structure</td>
+              <td>Requires Google account data request</td>
+            </tr>
+            <tr>
+              <td><strong>DeepSeek</strong></td>
+              <td>None</td>
+              <td>N/A</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td><strong>Perplexity</strong></td>
+              <td>None</td>
+              <td>N/A</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td><strong>Most Others</strong></td>
+              <td>None</td>
+              <td>N/A</td>
+              <td>N/A</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>AI Chat Exporter solves this by giving you per-conversation, on-demand exports in clean, readable formats. No waiting for email archives. No parsing nested JSON. No API keys. Just click, choose a format, and save.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Recommended Backup Formats</h2>
+      <p>Different formats serve different backup purposes. Here is what to use depending on your goals:</p>
+      <div class="features-grid">
+        <div class="feature-card">
+          <h3>Markdown (.md)</h3>
+          <p><strong>Best for:</strong> Human-readable archives, Obsidian vaults, searchable backup folders. Markdown is lightweight, universal, and works with virtually every text editor and knowledge management tool. Code blocks preserve syntax, tables stay structured, and math equations render in compatible editors.</p>
+        </div>
+        <div class="feature-card">
+          <h3>JSON (.json)</h3>
+          <p><strong>Best for:</strong> Programmatic access, data analysis, automated pipelines. The JSON export includes structured metadata: source platform, conversation title, timestamps, and message roles. You can query, filter, and analyze your conversation history with scripts or data tools.</p>
+        </div>
+        <div class="feature-card">
+          <h3>PDF (.pdf)</h3>
+          <p><strong>Best for:</strong> Permanent archival, legal records, printing. PDFs are self-contained and render identically on any device. AI Chat Exporter supports dark and light themes, table of contents, and page breaks for clean printed output.</p>
+        </div>
+      </div>
+      <div class="callout callout-info">
+        <strong>Pro tip:</strong> Use Markdown as your primary backup format and JSON as a secondary structured archive. Markdown gives you human-readable, searchable files. JSON gives you machine-readable data with metadata that Markdown cannot represent.
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Recommended Backup Workflow</h2>
+      <div class="steps">
+        <div class="step">
+          <div class="step-number">1</div>
+          <div class="step-content">
+            <h3>Create a Backup Directory</h3>
+            <p>Set up a dedicated folder for your AI conversation backups. A good structure is organized by platform and date: <code>backups/chatgpt/2026/</code>, <code>backups/claude/2026/</code>. This keeps things organized from the start.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">2</div>
+          <div class="step-content">
+            <h3>Configure Filename Templates</h3>
+            <p>AI Chat Exporter supports filename templates that control how exported files are named. A useful backup template is <code>{platform}/{year}-{month}/{title}</code>. This automatically organizes files into platform and date folders.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">3</div>
+          <div class="step-content">
+            <h3>Export Important Conversations</h3>
+            <p>After completing an important conversation, click the extension icon and export to Markdown (for readability) or JSON (for structured data). For critical conversations, export to both formats. The whole process takes under 5 seconds.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">4</div>
+          <div class="step-content">
+            <h3>Sync to Cloud Storage (Optional)</h3>
+            <p>Since the export files are standard formats stored on your local machine, you can sync them to any cloud storage service (iCloud, Google Drive, Dropbox, Syncthing) using your preferred sync tool. This adds an off-machine backup layer without trusting any third-party backup service with your AI data.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>JSON Backup Schema</h2>
+      <p>For users who want to build tools around their backup archive, here is the structure of the JSON export:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>source</code></td>
+              <td>string</td>
+              <td>Platform name (e.g., "ChatGPT", "Claude")</td>
+            </tr>
+            <tr>
+              <td><code>title</code></td>
+              <td>string</td>
+              <td>Conversation title as shown on the platform</td>
+            </tr>
+            <tr>
+              <td><code>exportDate</code></td>
+              <td>ISO 8601</td>
+              <td>Timestamp of the export operation</td>
+            </tr>
+            <tr>
+              <td><code>messages</code></td>
+              <td>array</td>
+              <td>Array of message objects with role, content, and optional metadata</td>
+            </tr>
+            <tr>
+              <td><code>messages[].role</code></td>
+              <td>string</td>
+              <td>"user" or "assistant" (or "system" where applicable)</td>
+            </tr>
+            <tr>
+              <td><code>messages[].content</code></td>
+              <td>string</td>
+              <td>Message text content with Markdown formatting</td>
+            </tr>
+            <tr>
+              <td><code>messages[].timestamp</code></td>
+              <td>ISO 8601</td>
+              <td>Message timestamp (when the platform provides it)</td>
+            </tr>
+            <tr>
+              <td><code>metadata</code></td>
+              <td>object</td>
+              <td>Platform-specific metadata preserved from the parser (model name, reasoning type, etc. where available)</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>This schema makes it straightforward to write scripts that parse your backup archive, search for specific conversations, extract code snippets, or import conversations into other tools.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Filename Templates for Organized Backups</h2>
+      <p>AI Chat Exporter's filename template system lets you control exactly how backup files are named. Available variables include:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>Output</th>
+              <th>Example</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>{platform}</code></td>
+              <td>AI platform name</td>
+              <td>ChatGPT</td>
+            </tr>
+            <tr>
+              <td><code>{title}</code></td>
+              <td>Conversation title (sanitized)</td>
+              <td>React Hooks Debugging</td>
+            </tr>
+            <tr>
+              <td><code>{datetime}</code></td>
+              <td>Export timestamp</td>
+              <td>2026-09-08T14:30:00</td>
+            </tr>
+            <tr>
+              <td><code>{date}</code></td>
+              <td>Date only</td>
+              <td>2026-09-08</td>
+            </tr>
+            <tr>
+              <td><code>{year}</code></td>
+              <td>Year</td>
+              <td>2026</td>
+            </tr>
+            <tr>
+              <td><code>{month}</code></td>
+              <td>Month</td>
+              <td>09</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>A useful backup template is <code>{platform}/{year}-{month}/{title}</code>, which creates platform-specific folders organized by month. This makes it easy to browse your archive and find specific conversations.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Privacy-First Backup</h2>
+      <p>Most backup solutions ask you to trust a third-party service with your data. Cloud backup tools send your files to remote servers. Browser-based tools may phone home analytics. Even "local" tools sometimes include telemetry that leaks metadata about your conversations.</p>
+      <div class="callout callout-success">
+        <strong>Absolutely zero data leaves your browser.</strong> AI Chat Exporter runs entirely in the browser extension sandbox. All parsing, formatting, and file generation happen locally. The extension makes no network requests to any server. The source code is open under MPL 2.0 and auditable on GitHub.
+      </div>
+      <p>Your backup files are standard Markdown, JSON, or PDF files saved directly to your local filesystem. You control where they go, who can access them, and how they are synced. No third-party backup service has access to your conversation data unless you explicitly give it to them.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Backup All Your Conversations</h2>
+      <p>AI Chat Exporter exports the conversation open in your current tab. To back up your entire history, you export conversations one at a time as you work through them, using filename templates to organize the output. This is practical for:</p>
+      <ul>
+        <li><strong>Periodic backups</strong> &mdash; Export important conversations at the end of each week or month.</li>
+        <li><strong>Platform migration</strong> &mdash; Back up valuable threads before switching to a different AI platform.</li>
+        <li><strong>Compliance archiving</strong> &mdash; Create a record of AI-assisted work for audit purposes.</li>
+        <li><strong>Pre-deletion cleanup</strong> &mdash; Export conversations before clearing your history on platforms that enforce limits.</li>
+      </ul>
+      <div class="callout callout-info">
+        <p><strong>Tip:</strong> The filename template <code>{platform} - {title} - {datetime}</code> adds the source platform, conversation title, and timestamp to every export, so files from multiple platforms and sessions never collide and sort cleanly in your backup folder.</p>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq">
+        <div class="faq-item">
+          <button class="faq-question">How do I backup all my chats at once?</button>
+          <div class="faq-answer">
+            <p>AI Chat Exporter backs up the conversation currently open in your tab. You export each important conversation as you go; filename templates (such as <code>{platform} - {title} - {datetime}</code>) keep every file uniquely named and organized. There is no background auto-backup, but exporting an open conversation takes a single click, so a quick run through your recent chats produces a complete archive.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">What format should I use for backup?</button>
+          <div class="faq-answer">
+            <p>For most users, Markdown is the best primary backup format. It is human-readable, universally supported, and preserves code blocks and formatting. Use JSON as a secondary format if you want to build scripts or tools around your backup archive. PDF is best for permanent archival where visual fidelity matters. Export to multiple formats for important conversations.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Can I automate backups?</button>
+          <div class="faq-answer">
+            <p>AI Chat Exporter is a browser extension and requires user interaction to initiate exports. There is no built-in scheduled backup feature. However, you can combine the extension with your operating system's file sync tools (Syncthing, iCloud, Google Drive) to automatically sync exported files to other devices once they are saved locally. The extension also supports keyboard shortcuts for faster manual exports.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">How do I restore from a backup?</button>
+          <div class="faq-answer">
+            <p>Markdown backups can be opened in any text editor, Obsidian, or knowledge management tool. JSON backups can be read by scripts or imported into databases. PDF backups can be opened in any PDF reader. To continue a conversation on an AI platform, use the cross-AI transfer feature to send the conversation content to the platform's chat input. AI Chat Exporter cannot directly import files back into platform-specific conversation formats.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Is my data sent to any server during export?</button>
+          <div class="faq-answer">
+            <p>No. All processing happens locally within your browser extension. The extension reads the conversation from the page DOM, formats it, and saves the file directly to your filesystem. No data is transmitted to any external server, including our own. The extension's source code is open and auditable on GitHub.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">How large are the backup files?</button>
+          <div class="faq-answer">
+            <p>File size depends on conversation length and format. A typical 20-message conversation exports to approximately 15-30 KB in Markdown, 20-40 KB in JSON, and 50-100 KB in PDF (due to embedded fonts and formatting). Conversations with many code blocks or images will be larger. A year of daily AI usage might produce 50-200 MB of backup files in Markdown format.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="json-exporter.html" class="related-link">
+          <h3>JSON Exporter</h3>
+          <p>Structured JSON export with metadata, timestamps, and message roles for programmatic use.</p>
+        </a>
+        <a href="markdown-exporter.html" class="related-link">
+          <h3>Markdown Exporter</h3>
+          <p>Clean Markdown export with code highlighting, math, and formatting for human-readable backups.</p>
+        </a>
+        <a href="chatgpt-exporter.html" class="related-link">
+          <h3>ChatGPT Exporter</h3>
+          <p>Export ChatGPT conversations including Deep Research, Canvas placeholders, and thought process.</p>
+        </a>
+        <a href="cross-ai-transfer.html" class="related-link">
+          <h3>Cross-AI Transfer</h3>
+          <p>Move conversations between AI platforms to continue work on the best tool for the job.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <div class="callout callout-success">
+        <strong>Start backing up your AI conversations today.</strong> Install AI Chat Exporter, export your most important conversations, and build a searchable archive of your AI-assisted work. Free, local, and private.
+        <div class="cta-group">
+          <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+          <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/chatgpt-exporter.html
+++ b/docs/chatgpt-exporter.html
@@ -211,21 +211,18 @@
       <h2>How It Works</h2>
       <div class="steps" data-testid="steps">
         <div class="step">
-          <div class="step-number">1</div>
           <div class="step-content">
             <h3>Install the Extension</h3>
             <p>Add AI Chat Exporter from the Chrome Web Store, Firefox Add-ons, or Edge Add-ons. The extension installs in seconds and requires no configuration to start exporting.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">2</div>
           <div class="step-content">
             <h3>Open a ChatGPT Conversation</h3>
             <p>Navigate to any conversation in ChatGPT. The extension detects the active conversation and enables the export toolbar automatically.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">3</div>
           <div class="step-content">
             <h3>Choose Format and Export</h3>
             <p>Select your desired format from the export dropdown. The extension parses the conversation, applies formatting, and downloads the file to your machine. Optionally select specific messages before exporting.</p>
@@ -314,7 +311,7 @@
     <section class="content-section" data-testid="section-final-cta">
       <div class="callout callout-success">
         <strong>Ready to export your ChatGPT conversations?</strong> Install AI Chat Exporter and start saving your conversations in seconds. No account required. No data leaves your browser.
-        <div class="cta-group" style="margin-top: 1rem;">
+        <div class="cta-group compact">
           <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
           <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
         </div>
@@ -332,9 +329,21 @@
   </footer>
 
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
       btn.addEventListener('click', () => {
-        btn.closest('.faq-item').classList.toggle('open');
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
       });
     });
   </script>

--- a/docs/chatgpt-exporter.html
+++ b/docs/chatgpt-exporter.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ChatGPT Exporter — Export ChatGPT Conversations to Markdown, PDF & More</title>
+  <meta name="description" content="Export ChatGPT conversations to Markdown, PDF, JSON, HTML, Word and PNG. Free, open-source browser extension. 100% local and private." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/chatgpt-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/chatgpt-exporter.html" />
+  <meta property="og:title" content="ChatGPT Exporter — Export ChatGPT Conversations to Markdown, PDF & More" />
+  <meta property="og:description" content="Export ChatGPT conversations to Markdown, PDF, JSON, HTML, Word and PNG. Free, open-source browser extension. 100% local and private." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header data-testid="header">
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+
+  <div class="breadcrumb" data-testid="breadcrumb">
+    <a href="index.html">Home</a> <span>›</span> <span>ChatGPT Exporter</span>
+  </div>
+
+  <main>
+    <div class="hero" data-testid="hero">
+      <span class="badge">Free &amp; Open Source</span>
+      <h1 data-testid="h1">ChatGPT Exporter — Save Every Conversation</h1>
+      <p class="hero-subtitle">Export your ChatGPT conversations to Markdown, PDF, JSON, HTML, Word, PNG and more. AI Chat Exporter is a free, open-source browser extension that runs entirely in your browser — no servers, no sign-up, no data leaves your machine.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener" data-testid="cta-chrome">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener" data-testid="cta-firefox">Add to Firefox</a>
+      </div>
+    </div>
+
+    <!-- Why Export ChatGPT Conversations -->
+    <section class="content-section" data-testid="section-why-export">
+      <h2>Why Export Your ChatGPT Conversations?</h2>
+      <p>ChatGPT stores your conversations in OpenAI's cloud, but you have no meaningful way to back them up, search them offline, or own a local copy. OpenAI's built-in data export bundles your entire account into an unusable JSON archive that requires technical effort to parse. AI Chat Exporter solves this problem by giving you clean, readable exports of individual conversations right from the ChatGPT interface.</p>
+      <p>Whether you are a developer preserving code-generation sessions, a researcher archiving literature reviews, or a professional keeping records of AI-assisted work, having a local copy of your conversations protects your work against accidental deletion, account issues, or platform changes.</p>
+      <p>Common reasons people export ChatGPT conversations:</p>
+      <ul>
+        <li><strong>Backup and archival</strong> — Keep a permanent local record before conversations are deleted or chats are purged.</li>
+        <li><strong>Knowledge management</strong> — Import conversations into Obsidian, Notion, Logseq, or any personal knowledge base as Markdown files.</li>
+        <li><strong>Sharing with colleagues</strong> — Send a clean PDF or Word document instead of a screenshot or copy-pasted text.</li>
+        <li><strong>Legal and compliance</strong> — Maintain audit trails of AI-assisted decisions and generated content.</li>
+        <li><strong>Research reference</strong> — Save technical discussions for future reference without relying on ChatGPT's search.</li>
+      </ul>
+    </section>
+
+    <!-- Supported Formats -->
+    <section class="content-section" data-testid="section-formats">
+      <h2>Supported Export Formats</h2>
+      <p>AI Chat Exporter supports seven output formats, each optimized for different use cases. You choose the format that fits your workflow — the extension handles parsing, formatting, and download.</p>
+      <div class="table-wrapper">
+        <table data-testid="formats-table">
+          <thead>
+            <tr>
+              <th>Format</th>
+              <th>Best For</th>
+              <th>Key Features</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Markdown</strong></td>
+              <td>Knowledge bases, documentation, Obsidian/Notion</td>
+              <td>Preserves code blocks, LaTeX math, tables, and images. Clean and editable.</td>
+            </tr>
+            <tr>
+              <td><strong>JSON</strong></td>
+              <td>Developers, automation pipelines, API integration</td>
+              <td>Structured data with source platform, timestamps, message roles, and a normalized schema.</td>
+            </tr>
+            <tr>
+              <td><strong>HTML</strong></td>
+              <td>Web archives, visual fidelity, embedding</td>
+              <td>Full visual representation with styled output that mirrors the chat interface.</td>
+            </tr>
+            <tr>
+              <td><strong>Word (.doc)</strong></td>
+              <td>Sharing with non-technical audiences, reports</td>
+              <td>Formatted document with headings, code blocks, and images. Editable in Word.</td>
+            </tr>
+            <tr>
+              <td><strong>PDF</strong></td>
+              <td>Archiving, printing, legal/compliance</td>
+              <td>Page breaks, table of contents, dark/light themes, custom fonts.</td>
+            </tr>
+            <tr>
+              <td><strong>PNG</strong></td>
+              <td>Visual sharing, social media, quick screenshots</td>
+              <td>Full conversation rendered as a scrollable image. Shareable anywhere.</td>
+            </tr>
+            <tr>
+              <td><strong>Continuation</strong></td>
+              <td>Resuming exported chats in Claude or other platforms</td>
+              <td>Special format that preserves conversation structure for re-import.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- ChatGPT-Specific Features -->
+    <section class="content-section" data-testid="section-chatgpt-features">
+      <h2>ChatGPT-Specific Features</h2>
+      <p>AI Chat Exporter is not a generic web scraper — it is purpose-built for every AI chat platform. For ChatGPT specifically, it handles features that other tools ignore:</p>
+      <div class="features-grid">
+        <div class="feature-card" data-testid="feature-deep-research">
+          <h3>Deep Research Export</h3>
+          <p>ChatGPT's Deep Research feature produces long, citation-heavy responses with embedded sources. AI Chat Exporter captures the full research output including citations, source links, and structured analysis — not just the visible text.</p>
+        </div>
+        <div class="feature-card" data-testid="feature-canvas">
+          <h3>Canvas Support</h3>
+          <p>ChatGPT Canvas documents are detected and represented in exports. Canvas outputs appear as clearly labeled placeholders (e.g. <code>[Canvas: title]</code>) so the conversation flow stays intact and you know a Canvas document was part of the exchange.</p>
+        </div>
+        <div class="feature-card" data-testid="feature-thought-process">
+          <h3>Thought Process Export</h3>
+          <p>When ChatGPT displays its reasoning or thinking steps, the extension captures them. This is useful for understanding how the model arrived at an answer — especially for technical and mathematical discussions.</p>
+        </div>
+        <div class="feature-card" data-testid="feature-group-conversations">
+          <h3>Group Conversation Support</h3>
+          <p>ChatGPT allows multiple models in a single conversation (e.g., switching between GPT-4o and o1). AI Chat Exporter correctly attributes each response to its model, preserving the conversation's true structure.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ChatGPT Built-in Export vs AI Chat Exporter -->
+    <section class="content-section" data-testid="section-comparison">
+      <h2>ChatGPT's Built-in Export vs. AI Chat Exporter</h2>
+      <p>OpenAI offers a "Export data" option in ChatGPT settings. Here is what you actually get and why it falls short:</p>
+      <div class="table-wrapper">
+        <table data-testid="comparison-table">
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th>OpenAI Data Export</th>
+              <th>AI Chat Exporter</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Export scope</td>
+              <td>All conversations at once (entire account)</td>
+              <td>Individual conversations or selected messages</td>
+            </tr>
+            <tr>
+              <td>Output format</td>
+              <td>Single JSON archive</td>
+              <td>Markdown, JSON, HTML, Word, PDF, PNG, Continuation</td>
+            </tr>
+            <tr>
+              <td>Readability</td>
+              <td>Raw JSON — not human-readable</td>
+              <td>Clean, formatted output ready to read and share</td>
+            </tr>
+            <tr>
+              <td>Selective export</td>
+              <td>No — all or nothing</td>
+              <td>Yes — choose specific messages or the full conversation</td>
+            </tr>
+            <tr>
+              <td>Code formatting</td>
+              <td>Stripped of formatting</td>
+              <td>Preserved with syntax highlighting and language tags</td>
+            </tr>
+            <tr>
+              <td>Images</td>
+              <td>Included as URLs (expire)</td>
+              <td>Embedded inline in the output</td>
+            </tr>
+            <tr>
+              <td>Speed</td>
+              <td>Hours to receive via email</td>
+              <td>Instant — exported in seconds</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout callout-info" data-testid="callout-info">
+        <strong>Tip:</strong> OpenAI's data export is useful for GDPR compliance requests, but for everyday use, AI Chat Exporter gives you clean, usable files in seconds.
+      </div>
+    </section>
+
+    <!-- How It Works -->
+    <section class="content-section" data-testid="section-how-it-works">
+      <h2>How It Works</h2>
+      <div class="steps" data-testid="steps">
+        <div class="step">
+          <div class="step-number">1</div>
+          <div class="step-content">
+            <h3>Install the Extension</h3>
+            <p>Add AI Chat Exporter from the Chrome Web Store, Firefox Add-ons, or Edge Add-ons. The extension installs in seconds and requires no configuration to start exporting.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">2</div>
+          <div class="step-content">
+            <h3>Open a ChatGPT Conversation</h3>
+            <p>Navigate to any conversation in ChatGPT. The extension detects the active conversation and enables the export toolbar automatically.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">3</div>
+          <div class="step-content">
+            <h3>Choose Format and Export</h3>
+            <p>Select your desired format from the export dropdown. The extension parses the conversation, applies formatting, and downloads the file to your machine. Optionally select specific messages before exporting.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Privacy -->
+    <section class="content-section" data-testid="section-privacy">
+      <h2>Your Data Never Leaves Your Browser</h2>
+      <p>AI Chat Exporter is built with privacy as a core principle. The extension runs entirely within your browser's sandbox — there are no external servers, no analytics, no telemetry, and no data collection of any kind.</p>
+      <div class="callout callout-success" data-testid="callout-privacy">
+        <strong>100% Local:</strong> All parsing, formatting, and file generation happen in your browser. The extension never contacts any external server. Your conversations stay on your machine.
+      </div>
+      <p>The source code is fully open under the MPL 2.0 license. You can audit every line of code on <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>. If you have security concerns, you can download the source and load it as an unpacked extension yourself.</p>
+    </section>
+
+    <!-- FAQ -->
+    <section class="content-section" data-testid="section-faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq">
+        <div class="faq-item" data-testid="faq-item-1">
+          <button class="faq-question">Does it export ChatGPT Plus conversations?</button>
+          <div class="faq-answer">
+            <p>Yes. AI Chat Exporter works with all ChatGPT tiers, including the free tier, Plus, Team, and Enterprise. It exports any conversation visible in your ChatGPT interface regardless of your subscription level.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-2">
+          <button class="faq-question">Can I export specific messages instead of the entire conversation?</button>
+          <div class="faq-answer">
+            <p>Yes. The extension lets you select individual messages before exporting. Check the messages you want, choose your format, and only those messages will be included in the output. This is useful for extracting a single code snippet or a specific answer from a long conversation.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-3">
+          <button class="faq-question">Does it support ChatGPT Deep Research?</button>
+          <div class="faq-answer">
+            <p>Yes. Deep Research outputs are fully captured, including all citations, source references, and the structured analysis that ChatGPT generates. The extension preserves the research hierarchy and formatting in every export format.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-4">
+          <button class="faq-question">What about Canvas outputs?</button>
+          <div class="faq-answer">
+            <p>ChatGPT Canvas documents are detected and represented in exports as labeled placeholders (e.g. <code>[Canvas: title]</code>). This keeps the conversation flow intact and makes it clear a Canvas document was part of the exchange, even though the live Canvas preview itself cannot be re-embedded in a Markdown or JSON file.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-5">
+          <button class="faq-question">Is AI Chat Exporter completely free?</button>
+          <div class="faq-answer">
+            <p>Yes. AI Chat Exporter is free and open source under the MPL 2.0 license. There are no premium tiers, no subscriptions, and no in-app purchases. All features are available to all users.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-6">
+          <button class="faq-question">Does it work on mobile browsers?</button>
+          <div class="faq-answer">
+            <p>AI Chat Exporter is a browser extension and works on desktop browsers (Chrome, Firefox, Edge). Mobile browsers like Chrome for Android and Safari for iOS do not support browser extensions. For mobile use, open ChatGPT on a desktop browser and export from there.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Related Pages -->
+    <section class="content-section" data-testid="section-related">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="chatgpt-to-markdown.html" class="related-link" data-testid="related-1">
+          <h3>ChatGPT to Markdown</h3>
+          <p>Export ChatGPT conversations as clean Markdown files with code blocks and LaTeX preserved.</p>
+        </a>
+        <a href="chatgpt-to-pdf.html" class="related-link" data-testid="related-2">
+          <h3>ChatGPT to PDF</h3>
+          <p>Generate print-ready PDFs from ChatGPT conversations with custom themes and layouts.</p>
+        </a>
+        <a href="claude-exporter.html" class="related-link" data-testid="related-3">
+          <h3>Claude Exporter</h3>
+          <p>Export Claude conversations to Markdown, PDF, JSON, HTML, Word, and PNG.</p>
+        </a>
+        <a href="gemini-exporter.html" class="related-link" data-testid="related-4">
+          <h3>Gemini Exporter</h3>
+          <p>Export Google Gemini conversations with the same formats and privacy guarantees.</p>
+        </a>
+      </div>
+    </section>
+
+    <!-- Additional CTA -->
+    <section class="content-section" data-testid="section-final-cta">
+      <div class="callout callout-success">
+        <strong>Ready to export your ChatGPT conversations?</strong> Install AI Chat Exporter and start saving your conversations in seconds. No account required. No data leaves your browser.
+        <div class="cta-group" style="margin-top: 1rem;">
+          <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+          <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer data-testid="footer">
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => {
+        btn.closest('.faq-item').classList.toggle('open');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/docs/chatgpt-to-markdown.html
+++ b/docs/chatgpt-to-markdown.html
@@ -1,0 +1,358 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ChatGPT to Markdown — Export ChatGPT Conversations as .md Files</title>
+  <meta name="description" content="Convert ChatGPT conversations to clean Markdown files. Preserves code blocks, LaTeX math, tables, and images. Free browser extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/chatgpt-to-markdown.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/chatgpt-to-markdown.html" />
+  <meta property="og:title" content="ChatGPT to Markdown — Export ChatGPT Conversations as .md Files" />
+  <meta property="og:description" content="Convert ChatGPT conversations to clean Markdown files. Preserves code blocks, LaTeX math, tables, and images. Free browser extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header data-testid="header">
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+
+  <div class="breadcrumb" data-testid="breadcrumb">
+    <a href="index.html">Home</a> <span>›</span> <span>ChatGPT to Markdown</span>
+  </div>
+
+  <main>
+    <div class="hero" data-testid="hero">
+      <span class="badge">Most Popular Format</span>
+      <h1 data-testid="h1">ChatGPT to Markdown — Clean Exports, Every Time</h1>
+      <p class="hero-subtitle">Convert ChatGPT conversations into clean, portable Markdown files. AI Chat Exporter preserves code blocks, LaTeX math, tables, and images — giving you files that work in Obsidian, Notion, GitHub, and any text editor.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener" data-testid="cta-chrome">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener" data-testid="cta-firefox">Add to Firefox</a>
+      </div>
+    </div>
+
+    <!-- Why Markdown -->
+    <section class="content-section" data-testid="section-why-markdown">
+      <h2>Why Markdown Is the Best Format for ChatGPT Exports</h2>
+      <p>Markdown is the lingua franca of technical writing. It is supported by virtually every note-taking app, documentation tool, and version control platform on the planet. When you export a ChatGPT conversation as Markdown, you get a file that:</p>
+      <ul>
+        <li><strong>Opens anywhere</strong> — Any text editor can read a .md file. No proprietary software required.</li>
+        <li><strong>Imports into knowledge bases</strong> — Drag and drop into Obsidian, Notion, Logseq, Roam Research, or Bear. The formatting is preserved automatically.</li>
+        <li><strong>Works with Git</strong> — Commit your exported conversations to a repository for version control and searchability.</li>
+        <li><strong>Converts to other formats</strong> — Use pandoc, VS Code, or any Markdown renderer to convert to HTML, PDF, DOCX, or LaTeX with a single command.</li>
+        <li><strong>Stays human-readable</strong> — Even without rendering, raw Markdown is clean and readable in any editor.</li>
+      </ul>
+      <p>Other export formats have their place, but Markdown is the format that survives every workflow transition. It is the safe default for long-term archival.</p>
+    </section>
+
+    <!-- What the Markdown Output Looks Like -->
+    <section class="content-section" data-testid="section-output-preview">
+      <h2>What the Markdown Output Looks Like</h2>
+      <p>AI Chat Exporter produces well-structured Markdown that follows conventions compatible with GitHub Flavored Markdown and CommonMark. Here is an example of what an exported conversation looks like:</p>
+      <div class="callout callout-info" data-testid="callout-md-preview">
+<pre style="margin:0;overflow-x:auto;"><code># ChatGPT Conversation: Building a REST API in Python
+
+## User
+How do I create a REST API with FastAPI?
+
+## Assistant
+Here's a basic FastAPI example:
+
+```python
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+```
+
+Then run it with: `uvicorn main:app --reload`
+
+## User
+How do I add a database?
+
+## Assistant
+Use SQLAlchemy with FastAPI:
+
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = "sqlite:///./app.db"
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+```
+
+This sets up a local SQLite database connection...</code></pre>
+      </div>
+      <p>Each message is clearly attributed to its role (User or Assistant), code blocks retain their language tags, and the overall structure is flat and scannable.</p>
+    </section>
+
+    <!-- LaTeX Math Handling -->
+    <section class="content-section" data-testid="section-latex">
+      <h2>LaTeX Math Handling</h2>
+      <p>When ChatGPT generates mathematical expressions, AI Chat Exporter preserves them in standard LaTeX notation:</p>
+      <ul>
+        <li><strong>Block math</strong> — Display equations are wrapped in <code>$$...$$</code> delimiters, compatible with KaTeX, MathJax, and most Markdown renderers.</li>
+        <li><strong>Inline math</strong> — Inline expressions use <code>$...$</code> delimiters for seamless integration with surrounding text.</li>
+      </ul>
+      <p>This means exported files render beautifully in Obsidian (with the Math rendering plugin), Jupyter notebooks, GitHub READMEs, and any platform that supports LaTeX in Markdown.</p>
+      <div class="callout callout-info" data-testid="callout-latex-example">
+        <strong>Example:</strong> A quadratic formula from ChatGPT is exported as <code>$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$</code> rather than losing its formatting to plain text.
+      </div>
+    </section>
+
+    <!-- Code Block Preservation -->
+    <section class="content-section" data-testid="section-code-blocks">
+      <h2>Code Block Preservation</h2>
+      <p>Code is one of the most common things people ask ChatGPT about, and losing code formatting is the biggest problem with copy-paste exports. AI Chat Exporter handles code blocks correctly:</p>
+      <ul>
+        <li><strong>Language tags preserved</strong> — If ChatGPT marks a block as Python, JavaScript, SQL, etc., the exported Markdown retains the language identifier for syntax highlighting.</li>
+        <li><strong>Nested code blocks</strong> — Multi-block responses with different languages are each exported with their own language tag.</li>
+        <li><strong>Inline code</strong> — Backtick-wrapped inline code is preserved as-is.</li>
+        <li><strong>Indentation preserved</strong> — Whitespace and indentation within code blocks are maintained exactly as ChatGPT rendered them.</li>
+      </ul>
+      <p>This matters because most Markdown renderers (GitHub, VS Code, Obsidian, Jekyll) use the language tag to apply syntax highlighting. Without it, exported code blocks appear as unstyled plain text.</p>
+    </section>
+
+    <!-- Image Handling -->
+    <section class="content-section" data-testid="section-images">
+      <h2>Image Handling</h2>
+      <p>ChatGPT occasionally generates images (via DALL-E or image analysis). AI Chat Exporter handles images in two ways depending on the export configuration:</p>
+      <ul>
+        <li><strong>Embedded (default)</strong> — Images are included as base64-encoded data URIs within the Markdown file. The file is self-contained — no external dependencies. The tradeoff is larger file sizes.</li>
+        <li><strong>Linked</strong> — Images are referenced by their CDN URL. The Markdown file stays small, but the URLs may expire over time.</li>
+      </ul>
+      <p>For long-term archival, embedded images are recommended. For lightweight sharing, linked images are more practical.</p>
+    </section>
+
+    <!-- Selective Export and Filenames -->
+    <section class="content-section" data-testid="section-selective">
+      <h2>Selective Export and Custom Filenames</h2>
+      <p>You do not have to export entire conversations. AI Chat Exporter lets you select specific messages before exporting — useful when you only need a particular code snippet, answer, or exchange from a long thread.</p>
+      <p>The extension also supports filename templates for automatic, consistent naming:</p>
+      <div class="table-wrapper">
+        <table data-testid="filename-templates">
+          <thead>
+            <tr>
+              <th>Template Variable</th>
+              <th>Output</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>{platform}</code></td>
+              <td>chatgpt</td>
+            </tr>
+            <tr>
+              <td><code>{title}</code></td>
+              <td>The conversation title (sanitized for filenames)</td>
+            </tr>
+            <tr>
+              <td><code>{datetime}</code></td>
+              <td>Current date and time (ISO 8601 format)</td>
+            </tr>
+            <tr>
+              <td><code>{uuid}</code></td>
+              <td>A unique identifier for the conversation</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The default template is <code>{platform} - {title} - {datetime}</code>, producing filenames like <code>chatgpt - Building a REST API - 2026-09-09T1430.md</code>.</p>
+    </section>
+
+    <!-- Copy-Paste vs Extension -->
+    <section class="content-section" data-testid="section-copy-paste">
+      <h2>Copy-Paste vs. AI Chat Exporter</h2>
+      <p>Manually copying ChatGPT responses is the most common workaround, but it has significant limitations:</p>
+      <div class="table-wrapper">
+        <table data-testid="copy-paste-comparison">
+          <thead>
+            <tr>
+              <th>Aspect</th>
+              <th>Copy-Paste</th>
+              <th>AI Chat Exporter</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Code formatting</td>
+              <td>Lost — plain text, no language tags</td>
+              <td>Preserved with fenced blocks and language identifiers</td>
+            </tr>
+            <tr>
+              <td>Tables</td>
+              <td>Collapsed to plain text</td>
+              <td>Rendered as Markdown tables</td>
+            </tr>
+            <tr>
+              <td>Math expressions</td>
+              <td>Often garbled or lost</td>
+              <td>Preserved as LaTeX notation</td>
+            </tr>
+            <tr>
+              <td>Images</td>
+              <td>Not included (manual save required)</td>
+              <td>Automatically embedded or linked</td>
+            </tr>
+            <tr>
+              <td>Role attribution</td>
+              <td>Manual — you must label who said what</td>
+              <td>Automatic — User/Assistant headers added</td>
+            </tr>
+            <tr>
+              <td>Long conversations</td>
+              <td>Impractical — multiple copy operations</td>
+              <td>One click for the entire conversation</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- How It Works -->
+    <section class="content-section" data-testid="section-how-it-works">
+      <h2>How to Export ChatGPT to Markdown</h2>
+      <div class="steps" data-testid="steps">
+        <div class="step">
+          <div class="step-number">1</div>
+          <div class="step-content">
+            <h3>Install AI Chat Exporter</h3>
+            <p>Add the extension from the Chrome Web Store, Firefox Add-ons, or Edge Add-ons. Takes under 30 seconds with no configuration needed.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">2</div>
+          <div class="step-content">
+            <h3>Open Your ChatGPT Conversation</h3>
+            <p>Navigate to any conversation on chatgpt.com. The extension detects the page and activates the export toolbar.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">3</div>
+          <div class="step-content">
+            <h3>Click Export as Markdown</h3>
+            <p>Select "Markdown" from the export format dropdown. Optionally select specific messages. The .md file downloads instantly with all formatting preserved.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="content-section" data-testid="section-faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq">
+        <div class="faq-item" data-testid="faq-item-1">
+          <button class="faq-question">Does it preserve code formatting in Markdown?</button>
+          <div class="faq-answer">
+            <p>Yes. Code blocks are exported as fenced Markdown blocks with language tags (e.g., <code>```python</code>). Syntax highlighting is applied by whatever Markdown renderer you use — Obsidian, VS Code, GitHub, etc. Inline code wrapped in backticks is also preserved.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-2">
+          <button class="faq-question">Can I export only my prompts from a conversation?</button>
+          <div class="faq-answer">
+            <p>Yes. The extension lets you select individual messages before exporting. Simply check the messages you want — whether that is all your prompts, all assistant responses, or a specific exchange — and only those messages appear in the Markdown output.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-3">
+          <button class="faq-question">Does it handle LaTeX math expressions?</button>
+          <div class="faq-answer">
+            <p>Yes. Block-level math is exported as <code>$$...$$</code> and inline math as <code>$...$</code>. This notation is standard across KaTeX, MathJax, and most Markdown rendering engines. Obsidian, Jupyter, and GitHub all render it correctly.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-4">
+          <button class="faq-question">How do I import the Markdown into Obsidian?</button>
+          <div class="faq-answer">
+            <p>Drag and drop the .md file into your Obsidian vault folder, or use Obsidian's "Import file" option. The conversation will appear as a note with full formatting — code blocks, math, tables, and images (if embedded) all render correctly. You can also set up a filename template to match your Obsidian naming conventions.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-5">
+          <button class="faq-question">Can I include images in the Markdown export?</button>
+          <div class="faq-answer">
+            <p>Yes. By default, images are embedded as base64-encoded data URIs, making the Markdown file self-contained. You can also configure the extension to link images by URL instead, which keeps the file smaller but relies on external image hosting.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Related Pages -->
+    <section class="content-section" data-testid="section-related">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="chatgpt-exporter.html" class="related-link" data-testid="related-1">
+          <h3>ChatGPT Exporter</h3>
+          <p>Full guide to exporting ChatGPT conversations in all supported formats.</p>
+        </a>
+        <a href="chatgpt-to-pdf.html" class="related-link" data-testid="related-2">
+          <h3>ChatGPT to PDF</h3>
+          <p>Generate print-ready PDFs from ChatGPT conversations with custom layouts.</p>
+        </a>
+        <a href="markdown-exporter.html" class="related-link" data-testid="related-3">
+          <h3>Markdown Exporter</h3>
+          <p>General Markdown export features across all supported AI platforms.</p>
+        </a>
+        <a href="obsidian-export.html" class="related-link" data-testid="related-4">
+          <h3>Obsidian Export</h3>
+          <p>How to import AI chat exports directly into your Obsidian vault.</p>
+        </a>
+      </div>
+    </section>
+
+    <!-- Final CTA -->
+    <section class="content-section" data-testid="section-final-cta">
+      <div class="callout callout-success">
+        <strong>Start exporting ChatGPT to Markdown today.</strong> Install the extension, open a conversation, and get a clean .md file in seconds. No account, no servers, no data leaves your browser.
+        <div class="cta-group" style="margin-top: 1rem;">
+          <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+          <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer data-testid="footer">
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => {
+        btn.closest('.faq-item').classList.toggle('open');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/docs/chatgpt-to-markdown.html
+++ b/docs/chatgpt-to-markdown.html
@@ -186,7 +186,7 @@ This sets up a local SQLite database connection...</code></pre>
           </tbody>
         </table>
       </div>
-      <p>The default template is <code>{platform} - {title} - {datetime}</code>, producing filenames like <code>chatgpt - Building a REST API - 2026-09-09T1430.md</code>.</p>
+      <p>The default template is <code>{platform} - {title} - {datetime}</code>, producing filenames like <code>chatgpt - Building a REST API - 2026-09-09_14-30.md</code>.</p>
     </section>
 
     <!-- Copy-Paste vs Extension -->

--- a/docs/chatgpt-to-markdown.html
+++ b/docs/chatgpt-to-markdown.html
@@ -75,12 +75,12 @@
       <h2>What the Markdown Output Looks Like</h2>
       <p>AI Chat Exporter produces well-structured Markdown that follows conventions compatible with GitHub Flavored Markdown and CommonMark. Here is an example of what an exported conversation looks like:</p>
       <div class="callout callout-info" data-testid="callout-md-preview">
-<pre style="margin:0;overflow-x:auto;"><code># ChatGPT Conversation: Building a REST API in Python
+<pre class="md-preview"><code># ChatGPT Conversation: Building a REST API in Python
 
-## User
+## Prompt:
 How do I create a REST API with FastAPI?
 
-## Assistant
+## Response:
 Here's a basic FastAPI example:
 
 ```python
@@ -95,10 +95,10 @@ def read_root():
 
 Then run it with: `uvicorn main:app --reload`
 
-## User
+## Prompt:
 How do I add a database?
 
-## Assistant
+## Response:
 Use SQLAlchemy with FastAPI:
 
 ```python
@@ -112,7 +112,7 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 This sets up a local SQLite database connection...</code></pre>
       </div>
-      <p>Each message is clearly attributed to its role (User or Assistant), code blocks retain their language tags, and the overall structure is flat and scannable.</p>
+      <p>Each message is clearly attributed to its role (Prompt or Response), code blocks retain their language tags, and the overall structure is flat and scannable.</p>
     </section>
 
     <!-- LaTeX Math Handling -->
@@ -226,7 +226,7 @@ This sets up a local SQLite database connection...</code></pre>
             <tr>
               <td>Role attribution</td>
               <td>Manual — you must label who said what</td>
-              <td>Automatic — User/Assistant headers added</td>
+              <td>Automatic — Prompt/Response headers added</td>
             </tr>
             <tr>
               <td>Long conversations</td>
@@ -243,21 +243,18 @@ This sets up a local SQLite database connection...</code></pre>
       <h2>How to Export ChatGPT to Markdown</h2>
       <div class="steps" data-testid="steps">
         <div class="step">
-          <div class="step-number">1</div>
           <div class="step-content">
             <h3>Install AI Chat Exporter</h3>
             <p>Add the extension from the Chrome Web Store, Firefox Add-ons, or Edge Add-ons. Takes under 30 seconds with no configuration needed.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">2</div>
           <div class="step-content">
             <h3>Open Your ChatGPT Conversation</h3>
             <p>Navigate to any conversation on chatgpt.com. The extension detects the page and activates the export toolbar.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">3</div>
           <div class="step-content">
             <h3>Click Export as Markdown</h3>
             <p>Select "Markdown" from the export format dropdown. Optionally select specific messages. The .md file downloads instantly with all formatting preserved.</p>
@@ -330,7 +327,7 @@ This sets up a local SQLite database connection...</code></pre>
     <section class="content-section" data-testid="section-final-cta">
       <div class="callout callout-success">
         <strong>Start exporting ChatGPT to Markdown today.</strong> Install the extension, open a conversation, and get a clean .md file in seconds. No account, no servers, no data leaves your browser.
-        <div class="cta-group" style="margin-top: 1rem;">
+        <div class="cta-group compact">
           <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
           <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
         </div>
@@ -348,9 +345,21 @@ This sets up a local SQLite database connection...</code></pre>
   </footer>
 
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
       btn.addEventListener('click', () => {
-        btn.closest('.faq-item').classList.toggle('open');
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
       });
     });
   </script>

--- a/docs/chatgpt-to-pdf.html
+++ b/docs/chatgpt-to-pdf.html
@@ -182,21 +182,18 @@
       <h2>How to Export ChatGPT to PDF</h2>
       <div class="steps" data-testid="steps">
         <div class="step">
-          <div class="step-number">1</div>
           <div class="step-content">
             <h3>Install the Extension</h3>
             <p>Add AI Chat Exporter from the Chrome Web Store, Firefox Add-ons, or Edge Add-ons. It installs in seconds with no configuration required.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">2</div>
           <div class="step-content">
             <h3>Open Your ChatGPT Conversation</h3>
             <p>Navigate to any conversation on chatgpt.com. The export toolbar activates automatically when the extension detects a ChatGPT page.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">3</div>
           <div class="step-content">
             <h3>Select PDF and Customize</h3>
             <p>Choose "PDF" from the format dropdown. Select your options — page breaks, table of contents, dark or light theme — then click Export. The PDF generates in your browser and downloads instantly.</p>
@@ -265,7 +262,7 @@
     <section class="content-section" data-testid="section-final-cta">
       <div class="callout callout-success">
         <strong>Need a print-ready copy of your ChatGPT conversation?</strong> Install AI Chat Exporter and generate a professional PDF in seconds. No account, no servers, no data leaves your browser.
-        <div class="cta-group" style="margin-top: 1rem;">
+        <div class="cta-group compact">
           <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
           <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
         </div>
@@ -283,9 +280,21 @@
   </footer>
 
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
       btn.addEventListener('click', () => {
-        btn.closest('.faq-item').classList.toggle('open');
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
       });
     });
   </script>

--- a/docs/chatgpt-to-pdf.html
+++ b/docs/chatgpt-to-pdf.html
@@ -1,0 +1,293 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ChatGPT to PDF — Export ChatGPT Conversations as PDF Files</title>
+  <meta name="description" content="Export ChatGPT conversations to PDF with custom fonts, page breaks, table of contents, and dark/light themes. Free browser extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/chatgpt-to-pdf.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/chatgpt-to-pdf.html" />
+  <meta property="og:title" content="ChatGPT to PDF — Export ChatGPT Conversations as PDF Files" />
+  <meta property="og:description" content="Export ChatGPT conversations to PDF with custom fonts, page breaks, table of contents, and dark/light themes. Free browser extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header data-testid="header">
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+
+  <div class="breadcrumb" data-testid="breadcrumb">
+    <a href="index.html">Home</a> <span>›</span> <span>ChatGPT to PDF</span>
+  </div>
+
+  <main>
+    <div class="hero" data-testid="hero">
+      <span class="badge">Print Ready</span>
+      <h1 data-testid="h1">ChatGPT to PDF — Print-Ready Conversation Exports</h1>
+      <p class="hero-subtitle">Export ChatGPT conversations as professional PDF documents with custom page breaks, table of contents, dark and light themes, and typography options. AI Chat Exporter makes PDF generation simple and fast.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener" data-testid="cta-chrome">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener" data-testid="cta-firefox">Add to Firefox</a>
+      </div>
+    </div>
+
+    <!-- Why PDF -->
+    <section class="content-section" data-testid="section-why-pdf">
+      <h2>Why Export ChatGPT Conversations as PDF?</h2>
+      <p>PDF is the universal format for documents that need to look the same on every device. When you export a ChatGPT conversation as a PDF, you get a portable, print-ready file that preserves formatting without requiring any specific app to view it.</p>
+      <p>Unlike Markdown (which requires a renderer) or HTML (which requires a browser), PDF files are self-contained. The person receiving the document does not need any special software — every operating system, phone, and tablet can open a PDF natively.</p>
+      <p>Common use cases for ChatGPT PDF exports:</p>
+      <ul>
+        <li><strong>Archiving</strong> — Keep a permanent, fixed-layout record of important conversations that will not change over time.</li>
+        <li><strong>Sharing with non-technical people</strong> — Send a clean, formatted document to colleagues, clients, or managers who do not use Markdown or code editors.</li>
+        <li><strong>Legal and compliance</strong> — Produce printable audit trails of AI-assisted work for regulatory or documentation requirements.</li>
+        <li><strong>Presentations</strong> — Attach a conversation excerpt as supporting material in a report or proposal.</li>
+        <li><strong>Printing</strong> — Generate hard copies of research discussions, code reviews, or tutoring sessions.</li>
+      </ul>
+    </section>
+
+    <!-- How PDF Export Works -->
+    <section class="content-section" data-testid="section-how-pdf-works">
+      <h2>How PDF Export Works</h2>
+      <p>AI Chat Exporter generates PDFs using the browser's native print engine combined with custom CSS stylesheets. This approach has several advantages over server-side PDF generation:</p>
+      <ul>
+        <li><strong>No external services</strong> — The PDF is generated entirely in your browser. No data is uploaded to any server.</li>
+        <li><strong>Pixel-perfect rendering</strong> — The browser renders the conversation exactly as it appears in the extension, then the print engine converts it to PDF with accurate fonts, colors, and layouts.</li>
+        <li><strong>Full math support</strong> — LaTeX expressions are rendered by the browser's built-in math rendering before PDF conversion, so equations appear as properly typeset math — not as raw LaTeX code.</li>
+        <li><strong>Syntax-highlighted code</strong> — Code blocks retain their syntax highlighting in the PDF output, making them readable and visually distinct.</li>
+      </ul>
+      <p>The extension applies custom print styles that handle page margins, avoid orphaned headings, and ensure code blocks break cleanly across pages rather than cutting off mid-block.</p>
+    </section>
+
+    <!-- PDF Customization Options -->
+    <section class="content-section" data-testid="section-pdf-options">
+      <h2>PDF Customization Options</h2>
+      <p>AI Chat Exporter gives you control over how your PDF looks without requiring any design skills:</p>
+      <div class="features-grid">
+        <div class="feature-card" data-testid="feature-page-breaks">
+          <h3>Page Break Per Prompt</h3>
+          <p>Enable page breaks before each user prompt so that every question-and-answer exchange starts on a new page. This makes long conversations easier to navigate when printed or reviewed in a PDF reader.</p>
+        </div>
+        <div class="feature-card" data-testid="feature-table-of-contents">
+          <h3>Table of Contents</h3>
+          <p>When enabled, the extension generates a table of contents at the beginning of the PDF with clickable links to each section. Essential for conversations with 20+ exchanges.</p>
+        </div>
+        <div class="feature-card" data-testid="feature-themes">
+          <h3>Dark and Light Themes</h3>
+          <p>Choose between a dark theme (dark background, light text) for screen reading and a light theme (white background, dark text) for printing. Both themes are optimized for readability and ink efficiency.</p>
+        </div>
+        <div class="feature-card" data-testid="feature-filename">
+          <h3>Custom Filenames</h3>
+          <p>Use template variables like <code>{platform}</code>, <code>{title}</code>, and <code>{datetime}</code> to generate consistent, descriptive filenames automatically. No more "chat.pdf" in your downloads folder.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- PDF Output Quality -->
+    <section class="content-section" data-testid="section-pdf-quality">
+      <h2>PDF Output Quality</h2>
+      <p>AI Chat Exporter is designed to produce PDFs that look professional without manual cleanup:</p>
+      <ul>
+        <li><strong>Mathematical notation</strong> — LaTeX equations render as properly typeset math with correct sizing, spacing, and symbols. Both block equations ($$...$$) and inline math ($...$) display correctly.</li>
+        <li><strong>Code blocks</strong> — Fenced code blocks retain syntax highlighting, monospace fonts, and proper indentation. Long lines wrap naturally within page margins.</li>
+        <li><strong>Tables</strong> — Markdown tables render as grid tables with aligned columns, borders, and proper cell padding.</li>
+        <li><strong>Images</strong> — Embedded images display inline at appropriate sizes. The extension scales images to fit within page margins without distortion.</li>
+        <li><strong>Typography</strong> — The extension uses system fonts optimized for PDF rendering, ensuring consistent character spacing and line heights across platforms.</li>
+      </ul>
+      <div class="callout callout-info" data-testid="callout-print-tip">
+        <strong>Print Tip:</strong> For the best print results, use the Light theme and enable page breaks per prompt. This produces clean, professional-looking pages when sent to a printer or exported to PDF from the browser's print dialog.
+      </div>
+    </section>
+
+    <!-- Use Cases in Detail -->
+    <section class="content-section" data-testid="section-use-cases">
+      <h2>When to Use PDF vs. Other Formats</h2>
+      <div class="table-wrapper">
+        <table data-testid="format-comparison">
+          <thead>
+            <tr>
+              <th>Scenario</th>
+              <th>Best Format</th>
+              <th>Why</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Sending to a non-technical colleague</td>
+              <td><strong>PDF</strong></td>
+              <td>Universal viewer, no software required, looks professional.</td>
+            </tr>
+            <tr>
+              <td>Importing into Obsidian or Notion</td>
+              <td><strong>Markdown</strong></td>
+              <td>Native format for knowledge bases, searchable, editable.</td>
+            </tr>
+            <tr>
+              <td>Version controlling conversations</td>
+              <td><strong>Markdown</strong> or <strong>JSON</strong></td>
+              <td>Text-based, diffable, lightweight in Git.</td>
+            </tr>
+            <tr>
+              <td>Archiving with fixed formatting</td>
+              <td><strong>PDF</strong></td>
+              <td>Self-contained, rendering-independent, long-term stable.</td>
+            </tr>
+            <tr>
+              <td>Sharing on social media</td>
+              <td><strong>PNG</strong></td>
+              <td>Image format, visually shareable, no file opening required.</td>
+            </tr>
+            <tr>
+              <td>Feeding into automation pipelines</td>
+              <td><strong>JSON</strong></td>
+              <td>Structured data, machine-readable, easy to parse.</td>
+            </tr>
+            <tr>
+              <td>Printing a physical copy</td>
+              <td><strong>PDF</strong></td>
+              <td>Optimized for print with page breaks and margins.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- How It Works -->
+    <section class="content-section" data-testid="section-how-it-works">
+      <h2>How to Export ChatGPT to PDF</h2>
+      <div class="steps" data-testid="steps">
+        <div class="step">
+          <div class="step-number">1</div>
+          <div class="step-content">
+            <h3>Install the Extension</h3>
+            <p>Add AI Chat Exporter from the Chrome Web Store, Firefox Add-ons, or Edge Add-ons. It installs in seconds with no configuration required.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">2</div>
+          <div class="step-content">
+            <h3>Open Your ChatGPT Conversation</h3>
+            <p>Navigate to any conversation on chatgpt.com. The export toolbar activates automatically when the extension detects a ChatGPT page.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">3</div>
+          <div class="step-content">
+            <h3>Select PDF and Customize</h3>
+            <p>Choose "PDF" from the format dropdown. Select your options — page breaks, table of contents, dark or light theme — then click Export. The PDF generates in your browser and downloads instantly.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="content-section" data-testid="section-faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq">
+        <div class="faq-item" data-testid="faq-item-1">
+          <button class="faq-question">How do I save the ChatGPT conversation as a PDF?</button>
+          <div class="faq-answer">
+            <p>Install AI Chat Exporter, open a ChatGPT conversation, and select "PDF" from the export format dropdown. The extension generates the PDF in your browser and triggers a download. You can customize page breaks, table of contents, and theme before exporting.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-2">
+          <button class="faq-question">Can I customize the PDF layout?</button>
+          <div class="faq-answer">
+            <p>Yes. The extension provides options for page breaks (one per user prompt), a table of contents, dark or light theme, and custom filenames using template variables. These options are accessible from the export dropdown before generating the PDF.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-3">
+          <button class="faq-question">Does math render correctly in the PDF?</button>
+          <div class="faq-answer">
+            <p>Yes. LaTeX math expressions are rendered by the browser before PDF conversion, so equations appear as properly typeset math — not as raw code. Both block equations ($$...$$) and inline math ($...$) display with correct symbols, fractions, and spacing.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-4">
+          <button class="faq-question">Is there a page limit for PDF exports?</button>
+          <div class="faq-answer">
+            <p>No. The extension handles conversations of any length. Very long conversations (100+ exchanges) will produce proportionally longer PDFs. For readability, consider enabling page breaks per prompt so each exchange starts on a fresh page.</p>
+          </div>
+        </div>
+        <div class="faq-item" data-testid="faq-item-5">
+          <button class="faq-question">Can I select specific messages for the PDF?</button>
+          <div class="faq-answer">
+            <p>Yes. Before exporting, you can select individual messages using the checkboxes. Only the selected messages will be included in the PDF. This is useful for extracting a particular Q&A exchange from a longer conversation without including the full thread.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Related Pages -->
+    <section class="content-section" data-testid="section-related">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="chatgpt-exporter.html" class="related-link" data-testid="related-1">
+          <h3>ChatGPT Exporter</h3>
+          <p>Full overview of exporting ChatGPT conversations in all supported formats.</p>
+        </a>
+        <a href="chatgpt-to-markdown.html" class="related-link" data-testid="related-2">
+          <h3>ChatGPT to Markdown</h3>
+          <p>Export ChatGPT conversations as clean Markdown files with code and math preserved.</p>
+        </a>
+        <a href="pdf-exporter.html" class="related-link" data-testid="related-3">
+          <h3>PDF Exporter</h3>
+          <p>PDF export features across all supported AI chat platforms.</p>
+        </a>
+      </div>
+    </section>
+
+    <!-- Final CTA -->
+    <section class="content-section" data-testid="section-final-cta">
+      <div class="callout callout-success">
+        <strong>Need a print-ready copy of your ChatGPT conversation?</strong> Install AI Chat Exporter and generate a professional PDF in seconds. No account, no servers, no data leaves your browser.
+        <div class="cta-group" style="margin-top: 1rem;">
+          <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+          <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer data-testid="footer">
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => {
+        btn.closest('.faq-item').classList.toggle('open');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/docs/claude-exporter.html
+++ b/docs/claude-exporter.html
@@ -1,0 +1,242 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Claude Exporter — Export Claude AI Conversations to Markdown, PDF & More</title>
+  <meta name="description" content="Export Claude conversations to Markdown, PDF, JSON, HTML, Word and PNG. Supports Artifacts, Thinking Process, Tool Use. Free, open-source." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/claude-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/claude-exporter.html" />
+  <meta property="og:title" content="Claude Exporter — Export Claude AI Conversations to Markdown, PDF & More" />
+  <meta property="og:description" content="Export Claude conversations to Markdown, PDF, JSON, HTML, Word and PNG. Supports Artifacts, Thinking Process, Tool Use. Free, open-source." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>&rsaquo;</span> Claude Exporter</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Supports Artifacts &amp; Thinking</span>
+      <h1>Claude Exporter &mdash; Save Every Claude Conversation</h1>
+      <p class="hero-subtitle">Export your Anthropic Claude conversations to Markdown, PDF, JSON, HTML, Word, and PNG. Artifacts, Thinking Process, and Tool Use all captured from the page in one click.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <h2>Why Export Claude Conversations?</h2>
+    <p>Claude is one of the most capable AI assistants available today, handling everything from code generation to long-form research and creative writing. But Anthropic does not provide a built-in export mechanism for conversations. Once a chat scrolls past the context window or you navigate away, recovering specific details becomes tedious and unreliable.</p>
+    <p>The Claude Exporter feature inside AI Chat Exporter solves this by reading the Claude DOM directly in your browser and converting conversations into portable, searchable files. Everything runs locally in the extension&mdash;no data ever leaves your machine, no API keys are required, and no telemetry is collected.</p>
+
+    <h2>Claude-Specific Features</h2>
+    <div class="features-grid">
+      <div class="feature-card">
+        <h4>Artifacts with Version History</h4>
+        <p>Every Claude Artifacts you create during a conversation gets exported with its version history. Code, documents, and diagrams are saved as separate, well-formatted sections within the export.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Thinking Process</h4>
+        <p>Claude's extended thinking blocks are captured and included in the export as clearly separated reasoning sections &mdash; so you keep the reasoning trail as well as the final response.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Tool Use Steps</h4>
+        <p>When Claude calls tools or runs computation (widgets, data analysis, or Model Context Protocol tools), each invocation is captured with clear formatting so you can trace exactly what actions were performed during a conversation.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Selective Turn Export</h4>
+        <p>Don't need the entire conversation? Pick specific message turns and export only those. Ideal when you want to save one particular exchange without the surrounding context.</p>
+      </div>
+    </div>
+
+    <h2>Supported Export Formats</h2>
+    <p>AI Chat Exporter supports six output formats, each optimized for different use cases. Here is how each format handles Claude content:</p>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Format</th>
+            <th>Artifacts</th>
+            <th>Code Blocks</th>
+            <th>Images</th>
+            <th>Thinking</th>
+            <th>Best For</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Markdown (.md)</strong></td>
+            <td>Inline sections</td>
+            <td>PrismJS highlighted</td>
+            <td>Embedded as data URIs</td>
+            <td>Collapsible</td>
+            <td>Note-taking, Obsidian</td>
+          </tr>
+          <tr>
+            <td><strong>PDF (.pdf)</strong></td>
+            <td>Formatted blocks</td>
+            <td>Syntax colored</td>
+            <td>Inline images</td>
+            <td>Optional section</td>
+            <td>Printing, archival</td>
+          </tr>
+          <tr>
+            <td><strong>JSON (.json)</strong></td>
+            <td>Structured objects</td>
+            <td>Plain text in fields</td>
+            <td>Base64 encoded</td>
+            <td>Separate field</td>
+            <td>Developers, pipelines</td>
+          </tr>
+          <tr>
+            <td><strong>HTML (.html)</strong></td>
+            <td>Rendered preview</td>
+            <td>Syntax highlighted</td>
+            <td>Inline &lt;img&gt;</td>
+            <td>Collapsible</td>
+            <td>Web archival, sharing</td>
+          </tr>
+          <tr>
+            <td><strong>Word (.doc)</strong></td>
+            <td>Formatted text</td>
+            <td>Monospace blocks</td>
+            <td>Embedded images</td>
+            <td>Optional section</td>
+            <td>Documents, collaboration</td>
+          </tr>
+          <tr>
+            <td><strong>PNG (.png)</strong></td>
+            <td>Visual render</td>
+            <td>Highlighted</td>
+            <td>Captured inline</td>
+            <td>Optional</td>
+            <td>Sharing, social media</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>How Claude DOM Extraction Works</h2>
+    <p>AI Chat Exporter reads Claude conversations by inspecting the page's DOM structure. When you click the export button, the extension traverses the conversation elements in the active Claude tab, identifies user and assistant message boundaries, and extracts the raw content including markdown formatting, code blocks, and artifact containers.</p>
+    <p>For Artifacts, the extension detects Claude's artifact rendering containers and extracts each artifact's code or content along with its title and version number. This information is then passed to the appropriate format renderer (Markdown, PDF, etc.) which produces the final output file.</p>
+    <p>This DOM-based approach means no network requests are made. The extension never contacts Anthropic's servers or any third-party API. All processing happens within the browser's extension sandbox.</p>
+
+    <h2>Claude Exporter vs. Claude's Built-in Export</h2>
+    <p>Anthropic introduced a basic conversation export feature in Claude, but it comes with significant limitations:</p>
+    <ul>
+      <li><strong>Limited format support</strong> &mdash; Claude's native export only produces JSON. AI Chat Exporter offers Markdown, PDF, HTML, Word, and PNG in addition to JSON.</li>
+      <li><strong>No Artifact handling</strong> &mdash; Artifacts created during conversations are not properly exported by Claude's built-in tool. The exporter captures them with version history.</li>
+      <li><strong>No selective export</strong> &mdash; Claude exports the entire conversation or nothing. The exporter lets you pick specific turns.</li>
+      <li><strong>No Obsidian integration</strong> &mdash; Claude's export cannot send notes directly to your Obsidian vault. The exporter supports one-click Obsidian transfer via the obsidian:// URI scheme.</li>
+      <li><strong>No visual export</strong> &mdash; Need a PNG screenshot of a conversation for sharing? Claude's export does not support image output.</li>
+    </ul>
+    <p>For users who rely on Claude as a primary AI tool, having a dedicated exporter that understands Claude's unique features like Artifacts, Thinking Process, and Tool Use is essential for maintaining a complete knowledge archive.</p>
+
+    <div class="callout callout-success">
+      <p><strong>Open source and transparent.</strong> AI Chat Exporter is built under the MPL 2.0 license. You can audit the full source code on GitHub to verify that no data is transmitted externally. The extension requests only the minimum browser permissions needed to access the Claude tab.</p>
+    </div>
+
+    <div class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">Does the exporter capture Claude Artifacts with version history?</button>
+        <div class="faq-answer"><p>Yes. When you export a conversation that contains Artifacts, the exporter extracts each artifact's content, title, and version number. In Markdown and HTML exports, artifacts appear as labeled sections. In JSON exports, they are stored as structured objects with version arrays.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I export only specific parts of a Claude conversation?</button>
+        <div class="faq-answer"><p>Yes. The selective turn export feature lets you choose which message turns to include. After clicking the export button, you can select individual turns by their position in the conversation. This is useful when you want to save a particular exchange without exporting hundreds of preceding messages.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">How are Claude's Thinking Process blocks handled?</button>
+        <div class="faq-answer"><p>Claude's extended thinking content is captured as a separate section in the export. In Markdown exports, thinking content appears within a collapsible blockquote labeled "Thinking Process." In JSON, it is stored in a dedicated "thinking" field separate from the response content. Because the parser recognizes Claude's thinking blocks at the DOM level, the full reasoning chain is included whenever it is visible in the conversation.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Are tool calls and code execution captured?</button>
+        <div class="faq-answer"><p>Yes. When Claude invokes tools &mdash; including interactive widgets, data analysis, or Model Context Protocol integrations &mdash; each invocation and its result are captured. In Markdown and HTML exports, tool use steps appear inline with clear labels. In JSON, tool invocations and results are stored as structured data.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Is my conversation data sent to any server?</button>
+        <div class="faq-answer"><p>No. All extraction and formatting happens locally within your browser extension. The extension never contacts Anthropic's servers, our servers, or any third-party API. The only network requests the extension makes are to fetch its own CSS and font resources. You can verify this by inspecting the extension's source code on GitHub.</p></div>
+      </div>
+    </div>
+
+    <div class="related-pages">
+      <h3>Related Guides</h3>
+      <div class="related-grid">
+        <a href="claude-to-markdown.html" class="related-link">Claude to Markdown</a>
+        <a href="claude-to-obsidian.html" class="related-link">Claude to Obsidian</a>
+        <a href="chatgpt-exporter.html" class="related-link">ChatGPT Exporter</a>
+      </div>
+    </div>
+
+    <h2>How to Export Claude Conversations</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-content">
+          <h4>Install the Extension</h4>
+          <p>Add AI Chat Exporter from the Chrome Web Store or Firefox Add-ons. The extension requires minimal permissions&mdash;only access to the AI platform tabs you want to export from.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Open a Claude Conversation</h4>
+          <p>Navigate to claude.ai and open any conversation you want to export. The extension detects the active Claude tab automatically.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Click the Export Button</h4>
+          <p>Open the extension popup or side panel and select your preferred format. The extension reads the conversation from the page, processes Artifacts and Thinking blocks, and generates the output file.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Save or Transfer</h4>
+          <p>The file downloads automatically. Alternatively, use the Obsidian transfer button to send the note directly to your vault, or copy the content to your clipboard for pasting into another application.</p>
+        </div>
+      </div>
+    </div>
+
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/claude-exporter.html
+++ b/docs/claude-exporter.html
@@ -234,8 +234,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/claude-to-markdown.html
+++ b/docs/claude-to-markdown.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Claude to Markdown — Export Claude Conversations as Clean .md Files</title>
+  <meta name="description" content="Convert Claude conversations to Markdown with preserved code blocks, LaTeX math, Artifacts, and images. Free browser extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/claude-to-markdown.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/claude-to-markdown.html" />
+  <meta property="og:title" content="Claude to Markdown — Export Claude Conversations as Clean .md Files" />
+  <meta property="og:description" content="Convert Claude conversations to Markdown with preserved code blocks, LaTeX math, Artifacts, and images. Free browser extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>&rsaquo;</span> <a href="claude-exporter.html">Claude Exporter</a> <span>&rsaquo;</span> Claude to Markdown</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Preserves Artifacts</span>
+      <h1>Claude to Markdown &mdash; Clean, Structured Exports</h1>
+      <p class="hero-subtitle">Convert your Claude conversations into clean, portable Markdown files. Code blocks, LaTeX equations, Artifacts, and images are all preserved with proper formatting.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <h2>Why Markdown for Claude Conversations?</h2>
+    <p>Markdown is the lingua franca of technical documentation, note-taking, and knowledge management. It renders beautifully in Obsidian, Notion, GitHub, VS Code, and virtually every text editor. Unlike PDF or HTML, Markdown files are plain text&mdash;they are lightweight, diffable, version-controllable, and future-proof.</p>
+    <p>For Claude conversations specifically, Markdown is the natural choice because Claude itself produces Markdown-formatted responses. Code blocks, bullet lists, bold and italic text, headings, and tables all translate directly. The exporter preserves this structure rather than converting it to a less flexible format.</p>
+    <p>Whether you are archiving research threads, saving code generation sessions for later reference, or building a personal knowledge base, Markdown output keeps your Claude conversations in a format that remains useful years from now.</p>
+
+    <h2>How Artifacts Appear in Markdown</h2>
+    <p>One of the key differentiators of the Claude to Markdown export is how Artifacts are handled. Claude Artifacts&mdash;the code, documents, and visual content Claude generates in the side panel&mdash;are exported as clearly labeled sections within the Markdown file.</p>
+    <p>Each artifact appears under a level-3 heading with its title, followed by the artifact content in a fenced code block with the appropriate language tag. If an artifact went through multiple versions during the conversation, the exporter includes the latest version by default, with a note indicating version history was present. This approach keeps the Markdown file linear and readable while preserving the artifact context.</p>
+    <p>For example, a React component artifact exported to Markdown would appear as:</p>
+    <div class="callout callout-info">
+      <p><strong>Artifact: React TodoList Component</strong><br/>
+      The artifact code is wrapped in a <code>```jsx</code> fence with the artifact title as a heading above it, making it easy to find and copy.</p>
+    </div>
+
+    <h2>Code Block Handling with Syntax Highlighting</h2>
+    <p>Claude frequently generates code in its responses, and the quality of code preservation matters enormously for developers. The exporter uses PrismJS-compatible language detection to ensure every code block is tagged with the correct language identifier.</p>
+    <p>This means that when you open the exported Markdown file in any editor with syntax highlighting support (VS Code, Obsidian, Typora, GitHub), the code renders with proper coloring. Language tags like <code>python</code>, <code>javascript</code>, <code>typescript</code>, <code>rust</code>, <code>go</code>, and dozens more are automatically detected based on Claude's own language annotations and heuristics.</p>
+    <p>Inline code (backtick-wrapped phrases) is preserved as-is, and nested code blocks within lists or other structures are handled correctly without breaking the surrounding Markdown syntax.</p>
+
+    <h2>LaTeX Math Equations</h2>
+    <p>When Claude produces mathematical content, it uses LaTeX notation with dollar-sign delimiters. The exporter preserves these equations exactly as Claude outputs them. Both inline math (<code>$...$</code>) and display math (<code>$$...$$</code>) are maintained.</p>
+    <p>This is particularly important for academic and scientific conversations where equations are core content. When you open the exported file in a Markdown renderer that supports LaTeX (like Obsidian with the Math plugin, or a Jupyter-compatible viewer), the equations render as proper mathematical notation rather than raw syntax.</p>
+
+    <h2>Image Embedding</h2>
+    <p>Claude can generate and reference images in conversations. The exporter captures these images and embeds them as base64 data URIs directly within the Markdown file. This means the exported .md file is fully self-contained&mdash;no external image links that could break over time.</p>
+    <p>For conversations where images were uploaded by the user (such as screenshots or documents sent to Claude for analysis), those images are also captured and embedded. The result is a complete record of the visual context alongside the textual conversation.</p>
+
+    <h2>Selective Turn Export</h2>
+    <p>Sometimes you only need a specific exchange from a long Claude conversation. The selective turn export lets you choose exactly which message turns to include in the Markdown output. After clicking export, the extension presents the conversation turns and lets you select the range you want.</p>
+    <p>This feature is especially useful for research conversations where Claude might have explored multiple topics across dozens of exchanges. Instead of exporting everything, you can extract just the section where Claude produced the final analysis or recommendation you need.</p>
+
+    <h2>Filename Templates</h2>
+    <p>Exported Markdown files use intelligent filename templates that include the conversation title and a timestamp. The default template produces filenames like:</p>
+    <ul>
+      <li><code>Claude-React-Refactor-2026-03-15.md</code></li>
+      <li><code>Claude-Math-Proof-Derivation-2026-03-15.md</code></li>
+    </ul>
+    <p>You can customize the filename template in the extension settings to match your preferred naming convention. Options include adding project names, conversation IDs, or custom prefixes.</p>
+
+    <div class="callout callout-success">
+      <p><strong>100% local processing.</strong> The Markdown rendering happens entirely within the browser extension. Your conversation data is never transmitted to any external server. The exported .md file is generated in memory and saved directly to your downloads folder.</p>
+    </div>
+
+    <div class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">How are Artifacts represented in the Markdown output?</button>
+        <div class="faq-answer"><p>Each Artifact appears as a labeled section under a level-3 heading with its title. The artifact content is wrapped in a fenced code block with the appropriate language tag. If the artifact went through multiple versions, the latest version is included with a version note. In the exported file, artifacts are placed inline at the point where they were created in the conversation.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Does the exporter preserve code block language tags?</button>
+        <div class="faq-answer"><p>Yes. Language detection uses Claude's own annotations combined with heuristic analysis. The exported code blocks include the language identifier (e.g., ```python, ```typescript, ```rust) so syntax highlighting works correctly in any Markdown renderer that supports it.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I export LaTeX math equations properly?</button>
+        <div class="faq-answer"><p>Yes. Both inline ($...$) and display ($$...$$) LaTeX notation is preserved exactly as Claude outputs it. The equations will render correctly in any Markdown viewer with LaTeX support, such as Obsidian (with MathJax), Typora, or GitHub with MathJax enabled.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Are images embedded in the Markdown file or linked externally?</button>
+        <div class="faq-answer"><p>Images are embedded as base64 data URIs directly within the Markdown file. This makes the export self-contained&mdash;no external image links that could break. The tradeoff is that the file size will be larger when conversations contain many images.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">How do I export only part of a conversation?</button>
+        <div class="faq-answer"><p>Use the selective turn export feature. After clicking the export button, the extension shows the conversation turns and lets you select a range. Only the selected turns are included in the Markdown output. This works across all export formats, not just Markdown.</p></div>
+      </div>
+    </div>
+
+    <div class="related-pages">
+      <h3>Related Guides</h3>
+      <div class="related-grid">
+        <a href="claude-exporter.html" class="related-link">Claude Exporter (All Formats)</a>
+        <a href="claude-to-obsidian.html" class="related-link">Claude to Obsidian</a>
+        <a href="chatgpt-to-markdown.html" class="related-link">ChatGPT to Markdown</a>
+      </div>
+    </div>
+
+    <h2>How to Export Claude as Markdown</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-content">
+          <h4>Install AI Chat Exporter</h4>
+          <p>Install the extension from the Chrome Web Store or Firefox Add-ons. No account or API key is needed&mdash;just add the extension and it is ready to use.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Open Your Claude Conversation</h4>
+          <p>Navigate to claude.ai and open the conversation you want to export. The extension works with any active conversation, including those with Artifacts and Thinking blocks.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Select Markdown Format</h4>
+          <p>Click the extension icon and choose Markdown as the output format. Optionally configure filename templates, and include or exclude images using the settings panel.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Download the .md File</h4>
+          <p>The extension generates and downloads a clean Markdown file. Open it in your preferred editor or move it to your note-taking vault for permanent access.</p>
+        </div>
+      </div>
+    </div>
+
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/claude-to-markdown.html
+++ b/docs/claude-to-markdown.html
@@ -166,8 +166,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/claude-to-obsidian.html
+++ b/docs/claude-to-obsidian.html
@@ -175,8 +175,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/claude-to-obsidian.html
+++ b/docs/claude-to-obsidian.html
@@ -93,7 +93,7 @@
       <li><strong>Filename:</strong> <code>Claude-Refactor-React-Component.md</code></li>
       <li><strong>Full path:</strong> <code>Claude/2026/03/Claude-Refactor-React-Component.md</code></li>
     </ul>
-    <p>You can customize both the folder prefix and the filename template in the extension settings. Some users prefer flat organization (all notes in one folder), while others use nested year/month structures. Both are supported.</p>
+    <p>You can customize the filename template in the extension settings. For example, setting it to <code>Claude - {title} - {datetime}</code> produces unique, sortable filenames for every conversation. Note that filename separators like <code>/</code> are stripped for filesystem safety, so all exports land as flat files in your vault.</p>
 
     <h2>Why Obsidian Users Love This Workflow</h2>
     <p>Obsidian has become the go-to tool for developers and researchers who want a local-first, Markdown-based knowledge base. Claude conversations are a rich source of knowledge&mdash;code explanations, research summaries, creative drafts, and problem-solving threads. But manually copying these conversations into Obsidian is tedious and error-prone.</p>
@@ -142,7 +142,7 @@
       <div class="step">
         <div class="step-content">
           <h4>Configure Your Vault Name</h4>
-          <p>Open the AI Chat Exporter settings and enter your Obsidian vault name exactly as it appears in the vault switcher. Optionally set a target folder prefix like "Claude/" or "AI Conversations/".</p>
+          <p>Open the AI Chat Exporter settings and enter your Obsidian vault name exactly as it appears in the vault switcher. The note will be created at the root of your vault.</p>
         </div>
       </div>
       <div class="step">

--- a/docs/claude-to-obsidian.html
+++ b/docs/claude-to-obsidian.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Claude to Obsidian — Sync Claude Conversations to Your Obsidian Vault</title>
+  <meta name="description" content="Export Claude conversations directly to Obsidian as Markdown notes. Preserves code, math, Artifacts. One-click vault transfer. Free." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/claude-to-obsidian.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/claude-to-obsidian.html" />
+  <meta property="og:title" content="Claude to Obsidian — Sync Claude Conversations to Your Obsidian Vault" />
+  <meta property="og:description" content="Export Claude conversations directly to Obsidian as Markdown notes. Preserves code, math, Artifacts. One-click vault transfer. Free." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>&rsaquo;</span> <a href="claude-exporter.html">Claude Exporter</a> <span>&rsaquo;</span> Claude to Obsidian</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Direct Obsidian Integration</span>
+      <h1>Claude to Obsidian &mdash; One-Click Vault Transfer</h1>
+      <p class="hero-subtitle">Send Claude conversations directly into your Obsidian vault as properly formatted Markdown notes. No copy-paste, no file management. Just one click.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <h2>How Obsidian Integration Works</h2>
+    <p>AI Chat Exporter uses Obsidian's native <code>obsidian://new</code> URI scheme to create notes directly in your vault. When you click the Obsidian transfer button, the extension constructs a URI with the conversation content, vault name, and target folder, then opens it in a new tab. Obsidian intercepts the URI and creates the note instantly.</p>
+    <p>This approach has several advantages over file-based imports. There is no need to locate your vault folder on disk, no need to manually move files, and no risk of saving to the wrong location. The note appears in Obsidian exactly where you configured it to go, with the filename and folder path you specified.</p>
+    <p>The URI scheme approach also means the transfer works regardless of your operating system. Whether you are on Windows, macOS, or Linux, the obsidian:// protocol is handled uniformly by the Obsidian desktop application.</p>
+
+    <h2>Vault Name Configuration</h2>
+    <p>To use the Obsidian transfer feature, you need to tell the extension the name of your target vault. This is the display name of the vault as it appears in Obsidian&rsquo;s vault switcher, not the folder name on disk.</p>
+    <p>Open the extension settings and enter your vault name in the Obsidian vault field. If you have multiple vaults, you can configure different target folders for each. The extension stores this configuration in your browser's local extension storage&mdash;it is never shared with any external service.</p>
+
+    <div class="callout callout-info">
+      <p><strong>Tip:</strong> Your vault name is the name you see in Obsidian's top-left corner or in the vault switcher. It is not the folder path. For example, if your vault is called "Personal Knowledge Base", enter that exact name in the settings field.</p>
+    </div>
+
+    <h2>What Gets Transferred to Obsidian</h2>
+    <div class="features-grid">
+      <div class="feature-card">
+        <h4>Full Conversation Messages</h4>
+        <p>All user and assistant messages are included in the note. Messages are formatted as a clean Markdown document with clear speaker labels and timestamp markers where available.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Artifacts as Code Blocks</h4>
+        <p>Claude Artifacts are embedded inline with proper code fencing and language tags. They appear in the note at the point where they were created in the conversation, maintaining context.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Code with Syntax Tags</h4>
+        <p>All code blocks retain their language identifiers for syntax highlighting in Obsidian. The Obsidian theme you use will color-code the blocks automatically.</p>
+      </div>
+      <div class="feature-card">
+        <h4>LaTeX Math Equations</h4>
+        <p>Inline and display math notation is preserved. With Obsidian's MathJax plugin (enabled by default), equations render as proper mathematical notation.</p>
+      </div>
+    </div>
+
+    <h2>Filename and Folder Structure</h2>
+    <p>When a note is created in Obsidian, the filename is derived from the conversation title. The extension sanitizes the title to remove characters that are invalid in filenames (such as slashes, colons, and question marks) while preserving readability.</p>
+    <p>The default folder structure follows a date-based organization:</p>
+    <ul>
+      <li><strong>Folder:</strong> <code>Claude/2026/03/</code></li>
+      <li><strong>Filename:</strong> <code>Claude-Refactor-React-Component.md</code></li>
+      <li><strong>Full path:</strong> <code>Claude/2026/03/Claude-Refactor-React-Component.md</code></li>
+    </ul>
+    <p>You can customize both the folder prefix and the filename template in the extension settings. Some users prefer flat organization (all notes in one folder), while others use nested year/month structures. Both are supported.</p>
+
+    <h2>Why Obsidian Users Love This Workflow</h2>
+    <p>Obsidian has become the go-to tool for developers and researchers who want a local-first, Markdown-based knowledge base. Claude conversations are a rich source of knowledge&mdash;code explanations, research summaries, creative drafts, and problem-solving threads. But manually copying these conversations into Obsidian is tedious and error-prone.</p>
+    <p>The AI Chat Exporter Obsidian integration bridges this gap. Instead of opening a conversation, selecting all text, copying it, switching to Obsidian, creating a new note, and pasting (while losing code formatting and images), you click one button. The note appears in your vault with all formatting intact.</p>
+    <p>Over time, this creates a searchable archive of your AI interactions that you can link, tag, and reference just like any other Obsidian note. Cross-reference Claude's explanations with your own notes, create Maps of Content that link related conversations, or use Dataview queries to find all conversations about a specific topic.</p>
+
+    <div class="callout callout-success">
+      <p><strong>Privacy preserved.</strong> The Obsidian transfer uses a local URI scheme. No data is transmitted to the internet. The note is created directly in your local Obsidian vault by the Obsidian application itself.</p>
+    </div>
+
+    <div class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">How do I find my Obsidian vault name?</button>
+        <div class="faq-answer"><p>Open Obsidian and look at the top-left corner of the window. The vault name is displayed there. Alternatively, use the vault switcher (click the vault name or the icon next to it) to see all your vaults and their names. Enter the exact name in the extension's settings field.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Will images from Claude conversations appear in Obsidian?</button>
+        <div class="faq-answer"><p>Images are embedded as base64 data URIs in the Markdown note. Obsidian renders these inline. For conversations with many large images, the note file size may be significant. You can optionally disable image embedding in the extension settings if you prefer smaller notes.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I choose which conversations to send to Obsidian?</button>
+        <div class="faq-answer"><p>Yes. You can export the full conversation or use selective turn export to send only specific message turns. The Obsidian transfer respects the same selection settings as file-based exports.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">What happens if a note with the same name already exists?</button>
+        <div class="faq-answer"><p>Obsidian's obsidian://new URI scheme appends a numeric suffix to avoid overwriting existing notes. If "React Refactor.md" already exists, the new note will be named "React Refactor 2.md" or similar. Your existing notes are never overwritten.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Are Claude Artifacts handled differently in Obsidian?</button>
+        <div class="faq-answer"><p>Artifacts are included as labeled code blocks within the note. They appear under a heading with the artifact title, followed by a fenced code block with the appropriate language tag. This format is native Markdown, so Obsidian renders it correctly with syntax highlighting.</p></div>
+      </div>
+    </div>
+
+    <div class="related-pages">
+      <h3>Related Guides</h3>
+      <div class="related-grid">
+        <a href="claude-exporter.html" class="related-link">Claude Exporter (All Formats)</a>
+        <a href="claude-to-markdown.html" class="related-link">Claude to Markdown</a>
+        <a href="obsidian-export.html" class="related-link">Obsidian Export Guide</a>
+      </div>
+    </div>
+
+    <h2>How to Send Claude Chats to Obsidian</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-content">
+          <h4>Configure Your Vault Name</h4>
+          <p>Open the AI Chat Exporter settings and enter your Obsidian vault name exactly as it appears in the vault switcher. Optionally set a target folder prefix like "Claude/" or "AI Conversations/".</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Open a Claude Conversation</h4>
+          <p>Navigate to claude.ai and open any conversation. Works with conversations containing Artifacts, Thinking blocks, and Tool Use steps.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Click the Obsidian Transfer Button</h4>
+          <p>In the extension popup or side panel, click the Obsidian button. The extension constructs the note content and triggers the obsidian://new URI.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Note Appears in Your Vault</h4>
+          <p>Obsidian opens (or comes to the foreground) with the new note created. The conversation is now part of your knowledge base, ready to be linked, tagged, and searched.</p>
+        </div>
+      </div>
+    </div>
+
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/copilot-exporter.html
+++ b/docs/copilot-exporter.html
@@ -251,8 +251,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/copilot-exporter.html
+++ b/docs/copilot-exporter.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Microsoft Copilot Exporter — Export Copilot Chats to Markdown &amp; More</title>
+  <meta name="description" content="Export Microsoft Copilot conversations to Markdown, PDF, JSON, HTML, Word and PNG. Works with copilot.com and Bing Chat. Free extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/copilot-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/copilot-exporter.html" />
+  <meta property="og:title" content="Microsoft Copilot Exporter — Export Copilot Chats to Markdown &amp; More" />
+  <meta property="og:description" content="Export Microsoft Copilot conversations to Markdown, PDF, JSON, HTML, Word and PNG. Works with copilot.com and Bing Chat. Free extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>›</span> Copilot Exporter</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Bing &amp; Copilot</span>
+      <h1>Microsoft Copilot Exporter — Save Copilot Conversations</h1>
+      <p class="hero-subtitle">Export Microsoft Copilot and Bing Chat conversations to Markdown, JSON, HTML, PDF, Word, or PNG. Works across multiple Microsoft AI domains. Free and open source.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <h2>Microsoft Copilot's Unique Challenge</h2>
+    <p>Microsoft Copilot lives across multiple domains and has evolved through several branding changes. The same AI assistant is accessible at copilot.microsoft.com, copilot.com, and through Bing Chat at bing.com/chat. Each of these entry points uses a slightly different DOM structure, making generic export tools unreliable. Some miss messages entirely, others fail to capture Bing's search integration panels, and most do not handle the transition between Bing Chat and Copilot-branded pages gracefully.</p>
+    <p>Microsoft does not provide a built-in export or download feature for Copilot conversations. Once a chat session ends or you navigate away, the conversation is gone unless you manually copy it. For users who rely on Copilot for daily tasks, coding assistance, or content generation, this is a significant gap.</p>
+
+    <h2>Supported Copilot Domains</h2>
+    <p>AI Chat Exporter includes dedicated parsers for each Copilot variant. The extension automatically detects which domain you are on and applies the correct parsing logic.</p>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Domain</th>
+            <th>Also Known As</th>
+            <th>Parser Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>copilot.microsoft.com</strong></td>
+            <td>Microsoft Copilot (current)</td>
+            <td>Full support</td>
+          </tr>
+          <tr>
+            <td><strong>copilot.com</strong></td>
+            <td>Redirect to Microsoft Copilot</td>
+            <td>Full support</td>
+          </tr>
+          <tr>
+            <td><strong>bing.com/chat</strong></td>
+            <td>Bing Chat</td>
+            <td>Full support</td>
+          </tr>
+          <tr>
+            <td><strong>www.bing.com/search</strong></td>
+            <td>Bing Search with AI answers</td>
+            <td>Partial support</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>Features for Copilot Export</h2>
+    <div class="features-grid">
+      <div class="feature-card">
+        <h4>Bing Search Integration</h4>
+        <p>Copilot responses often include inline search results and source citations from Bing. The parser captures these reference panels and preserves their URLs in the export output.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Multi-Domain Detection</h4>
+        <p>The extension identifies which Copilot domain you are using and loads the appropriate DOM parser. No manual configuration is needed regardless of which entry point you used.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Image Descriptions</h4>
+        <p>When Copilot generates or references images, the export captures the image descriptions and alt text. In HTML and PNG exports, images are included where the source URLs are accessible.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Conversation History</h4>
+        <p>Both current and historical conversations visible on the page are captured. The parser handles the lazy-loaded message list that Copilot uses for long conversations.</p>
+      </div>
+    </div>
+
+    <h2>Export Formats</h2>
+    <p>All major formats are available for Copilot conversations, just as they are for every other supported platform.</p>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Format</th>
+            <th>Best For</th>
+            <th>Citations</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Markdown</strong></td>
+            <td>Note-taking, documentation</td>
+            <td>Inline links preserved</td>
+          </tr>
+          <tr>
+            <td><strong>JSON</strong></td>
+            <td>Data processing, automation</td>
+            <td>Structured citation objects</td>
+          </tr>
+          <tr>
+            <td><strong>HTML</strong></td>
+            <td>Web archives, sharing</td>
+            <td>Clickable source links</td>
+          </tr>
+          <tr>
+            <td><strong>PDF</strong></td>
+            <td>Printed records, compliance</td>
+            <td>Numbered references</td>
+          </tr>
+          <tr>
+            <td><strong>Word (.doc)</strong></td>
+            <td>Collaboration, editing</td>
+            <td>Hyperlinked footnotes</td>
+          </tr>
+          <tr>
+            <td><strong>PNG Image</strong></td>
+            <td>Social sharing, screenshots</td>
+            <td>Rendered visually</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>How to Export a Copilot Conversation</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-content">
+          <h4>Install the Extension</h4>
+          <p>Add AI Chat Exporter from the Chrome Web Store or Firefox Add-ons. The extension activates automatically on supported Microsoft domains.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Open Your Copilot Chat</h4>
+          <p>Navigate to copilot.microsoft.com or bing.com/chat and open the conversation you want to export. Both Copilot and Bing Chat are supported.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Click the Extension Icon</h4>
+          <p>Click the AI Chat Exporter icon in your browser toolbar. The extension detects the domain and loads the correct parser for your conversation.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Choose Format and Download</h4>
+          <p>Select your preferred format from the popup. The file downloads immediately with all messages, citations, and formatting preserved.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout callout-warning">
+      <p><strong>Known limitation:</strong> AI Chat Exporter is a read-only tool for Copilot. It can export conversations but cannot continue or resume them. For conversation continuation, see the full feature list on the home page for supported platforms.</p>
+    </div>
+
+    <h2>Copilot vs Other AI Platforms</h2>
+    <p>Microsoft Copilot has specific characteristics that affect how export works compared to other AI chatbots.</p>
+    <ul>
+      <li><strong>Domain fragmentation:</strong> Copilot is spread across multiple domains with different DOM structures. AI Chat Exporter handles each variant, while generic scrapers often break on one or more.</li>
+      <li><strong>Bing search integration:</strong> Copilot responses frequently cite web search results inline. The parser preserves these citations as structured data rather than stripping them.</li>
+      <li><strong>No official export:</strong> Unlike some competitors that offer export buttons, Microsoft provides no way to download Copilot conversations. Third-party tools fill this gap.</li>
+      <li><strong>Enterprise variants:</strong> Microsoft 365 Copilot uses a different interface entirely. AI Chat Exporter focuses on the consumer Copilot at copilot.microsoft.com. Enterprise Copilot export is not currently supported.</li>
+    </ul>
+
+    <div class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">Which Copilot domains are supported?</button>
+        <div class="faq-answer">
+          <p>AI Chat Exporter supports copilot.microsoft.com, copilot.com, and bing.com/chat. The Bing search page at bing.com/search has partial support for AI-generated answers. The extension automatically detects which domain you are on and applies the correct parser.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Does it work with the old Bing Chat?</button>
+        <div class="faq-answer">
+          <p>Yes. Bing Chat at bing.com/chat is fully supported. Whether you access Copilot through the Bing sidebar, the dedicated Bing Chat page, or the current copilot.microsoft.com interface, the extension captures your conversations correctly.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">What about Microsoft 365 Copilot in Office apps?</button>
+        <div class="faq-answer">
+          <p>AI Chat Exporter does not support Microsoft 365 Copilot within Word, Excel, PowerPoint, or Outlook. These embedded AI assistants use entirely different interfaces. The extension works with the standalone Copilot web application only.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">What formats can I export Copilot chats to?</button>
+        <div class="faq-answer">
+          <p>All major formats are supported: Markdown, JSON, HTML, PDF, Word (.doc), PNG image, and Continuation. Choose the format that fits your workflow from the extension popup.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Are there any limitations I should know about?</button>
+        <div class="faq-answer">
+          <p>The extension is export-only for Copilot. It captures what is currently visible in the conversation. If Copilot limits the scrollable history on a page, only the visible messages are captured. There is no continuation or resume feature for Copilot conversations. All export is local with no data leaving your browser.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="related-pages">
+      <h3>Other Exporters You Might Need</h3>
+      <div class="related-grid">
+        <a href="chatgpt-exporter.html" class="related-link">ChatGPT Exporter</a>
+        <a href="claude-exporter.html" class="related-link">Claude Exporter</a>
+        <a href="markdown-exporter.html" class="related-link">Markdown Exporter</a>
+      </div>
+    </div>
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/cross-ai-transfer.html
+++ b/docs/cross-ai-transfer.html
@@ -57,7 +57,7 @@
     <section class="content-section">
       <h2>What Is Cross-AI Transfer?</h2>
       <p>Every AI platform operates in its own silo. A conversation you start on ChatGPT cannot be continued on Claude. A thread in Gemini is locked inside Google's ecosystem. You cannot copy a conversation from one platform, paste it into another, and expect the AI to understand the context&mdash;the formatting breaks, the message roles get confused, and the AI treats your pasted content as a single block of text rather than a multi-turn exchange.</p>
-      <p>Cross-AI Transfer is a feature in AI Chat Exporter that solves this problem. It extracts a conversation from any of 18 supported platforms, strips out visual elements that cannot transfer (images, embeds), reformats the remaining text as a structured continuation prompt, and opens the target AI platform with the conversation ready to paste. The target AI receives the full conversation history with clear user/assistant role markers, allowing it to pick up where the last platform left off.</p>
+      <p>Cross-AI Transfer is a feature in AI Chat Exporter that solves this problem. It extracts a conversation from any of 17 supported platforms, strips out visual elements that cannot transfer (images, embeds), reformats the remaining text as a structured continuation prompt, and opens the target AI platform with the conversation automatically pre-filled into the chat input. The target AI receives the full conversation history with clear user/assistant role markers, allowing it to pick up where the last platform left off.</p>
       <p>No other browser extension, plugin, or tool offers this capability. It is unique to AI Chat Exporter.</p>
     </section>
 
@@ -73,7 +73,7 @@
           </thead>
           <tbody>
             <tr>
-              <td>All 18 supported platforms</td>
+              <td>All 17 supported platforms</td>
               <td>ChatGPT, Claude, Gemini, DeepSeek, Perplexity, Qwen, Mistral, NotebookLM, Copilot, Meta AI, Z.AI, AI Studio, Lumo, Joyland, Chub</td>
             </tr>
           </tbody>
@@ -86,31 +86,27 @@
       <h2>How It Works</h2>
       <div class="steps">
         <div class="step">
-          <div class="step-number">1</div>
           <div class="step-content">
             <h3>Extract the Conversation</h3>
             <p>Open the source conversation in your browser. AI Chat Exporter reads the page DOM and extracts all messages with their roles (user or assistant) and content. Code blocks, text formatting, and structured content are preserved.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">2</div>
           <div class="step-content">
             <h3>Strip Non-Transferable Elements</h3>
             <p>Images, embedded media, file uploads, and platform-specific UI elements are stripped from the conversation. These elements cannot be meaningfully transferred between platforms because each AI handles media differently. The text content and code are preserved.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">3</div>
           <div class="step-content">
             <h3>Format as Continuation Prompt</h3>
             <p>The conversation is reformatted with clear role markers. User messages are prefixed and assistant responses are clearly delimited. The result is a structured prompt that the target AI can parse as a multi-turn conversation rather than a raw text dump.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">4</div>
           <div class="step-content">
             <h3>Open Target Platform</h3>
-            <p>The extension stores the formatted conversation in <code>chrome.storage</code> as a pending continuation and opens the target platform in a new tab. When the platform loads, the conversation content is ready to paste into the chat input as your first message, giving the AI the full context.</p>
+            <p>The extension stores the formatted conversation in <code>chrome.storage</code> as a pending continuation and opens the target platform in a new tab. When the platform loads, the extension automatically inserts the conversation content into the chat input as your first message, giving the AI the full context. If automatic insertion fails, the content is available to paste manually.</p>
           </div>
         </div>
       </div>
@@ -154,7 +150,7 @@
         <li>ChatGPT starts giving shorter responses as it approaches its context limit.</li>
         <li>Click the AI Chat Exporter icon while on the ChatGPT tab. Select "Continue on Claude" from the cross-AI transfer menu.</li>
         <li>The extension extracts the conversation, strips the screenshots you pasted earlier, formats the remaining text and code with clear role markers, and stores it as a pending continuation.</li>
-        <li>A new tab opens to claude.ai. Start a new conversation and paste the content. Claude receives the full 30-message history with proper formatting and picks up the debugging session seamlessly.</li>
+        <li>A new tab opens to claude.ai. The extension auto-injects the 30-message history into the chat input with proper formatting. Review the pre-filled prompt and press send. Claude picks up the debugging session seamlessly. If the prompt is not auto-inserted (e.g. the page layout changed), paste it into the input manually.</li>
       </ol>
       <p>The same workflow works in reverse. Start on Claude, transfer to ChatGPT. Or start on DeepSeek, transfer to Gemini. The transfer is platform-agnostic.</p>
     </section>
@@ -178,7 +174,7 @@
       <h2>Technical Details</h2>
       <p>For developers who are curious about the implementation:</p>
       <ul>
-        <li><strong>Storage mechanism:</strong> The formatted conversation is stored in <code>chrome.storage.session</code> (or <code>browser.storage.session</code> on Firefox) as a <code>pendingContinuation</code> object. This is temporary storage that persists until the target tab is loaded.</li>
+        <li><strong>Storage mechanism:</strong> The formatted conversation is stored in <code>chrome.storage.local</code> (or <code>browser.storage.local</code> on Firefox) as a <code>pendingContinuation</code> object. The target content script checks for it on load, expiring it after 5 minutes, and removes it from storage after injecting the payload into a supported chat input.</li>
         <li><strong>Role markers:</strong> Messages are delimited with <code>[User]</code> and <code>[Assistant]</code> prefixes. This format is widely recognized by LLM chat interfaces and helps the target AI understand the conversation structure.</li>
         <li><strong>Image handling:</strong> The extension detects <code>&lt;img&gt;</code> elements and base64 data URIs in the conversation DOM and strips them. Alt text is preserved where available, giving the target AI a textual description of visual content.</li>
         <li><strong>Size limits:</strong> The transfer format is plain text, so extremely long conversations may exceed the target platform's input limits. The extension includes the full conversation as-is; if a chat exceeds the platform's limit, the target AI will typically accept only the recent portion. For typical conversations the full history transfers cleanly.</li>
@@ -191,7 +187,7 @@
         <div class="faq-item">
           <button class="faq-question">How do I transfer a conversation from one AI to another?</button>
           <div class="faq-answer">
-            <p>Open the conversation you want to transfer in your browser. Click the AI Chat Exporter extension icon and select the cross-AI transfer option. Choose your target platform from the list. The extension extracts the conversation, formats it, and opens the target platform in a new tab. Paste the content into the chat input to continue the conversation.</p>
+            <p>Open the conversation you want to transfer in your browser. Click the AI Chat Exporter extension icon and select the cross-AI transfer option. Choose your target platform from the list. The extension extracts the conversation, formats it, and opens the target platform in a new tab, where it automatically inserts the full conversation into the chat input. Review and submit the pre-filled prompt to continue the conversation. If auto-insertion does not fire (for example after a target-site layout change), paste the stored content into the chat input manually within 5 minutes.</p>
           </div>
         </div>
         <div class="faq-item">
@@ -201,9 +197,9 @@
           </div>
         </div>
         <div class="faq-item">
-          <button class="faq-question">Does it work with all 18 supported platforms?</button>
+          <button class="faq-question">Does it work with all supported platforms?</button>
           <div class="faq-answer">
-            <p>You can export from any of the 18 supported platforms. Cross-AI transfer targets 15 platforms where you can continue the conversation. All major platforms are covered: ChatGPT, Claude, Gemini, DeepSeek, Perplexity, Copilot, and more.</p>
+            <p>You can export from any of the 17 supported platforms. Cross-AI transfer targets 15 platforms where you can continue the conversation. All major platforms are covered: ChatGPT, Claude, Gemini, DeepSeek, Perplexity, Copilot, and more.</p>
           </div>
         </div>
         <div class="faq-item">
@@ -275,8 +271,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/cross-ai-transfer.html
+++ b/docs/cross-ai-transfer.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cross-AI Transfer — Move Conversations Between ChatGPT, Claude, Gemini &amp; More</title>
+  <meta name="description" content="Transfer AI conversations between ChatGPT, Claude, Gemini, DeepSeek, Perplexity and 10+ platforms. Continue chats on any AI. Free extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/cross-ai-transfer.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/cross-ai-transfer.html" />
+  <meta property="og:title" content="Cross-AI Transfer — Move Conversations Between ChatGPT, Claude, Gemini & More" />
+  <meta property="og:description" content="Transfer AI conversations between ChatGPT, Claude, Gemini, DeepSeek, Perplexity and 10+ platforms. Continue chats on any AI. Free extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>&rsaquo;</span> <span>Cross-AI Transfer</span></div>
+
+  <main>
+    <div class="hero">
+      <span class="badge">Unique Feature</span>
+      <h1>Cross-AI Transfer &mdash; Continue Anywhere</h1>
+      <p class="hero-subtitle">Take a conversation from ChatGPT and continue it on Claude. Move a Claude thread to Gemini. Transfer any AI chat to any other AI. No other tool does this.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <section class="content-section">
+      <h2>What Is Cross-AI Transfer?</h2>
+      <p>Every AI platform operates in its own silo. A conversation you start on ChatGPT cannot be continued on Claude. A thread in Gemini is locked inside Google's ecosystem. You cannot copy a conversation from one platform, paste it into another, and expect the AI to understand the context&mdash;the formatting breaks, the message roles get confused, and the AI treats your pasted content as a single block of text rather than a multi-turn exchange.</p>
+      <p>Cross-AI Transfer is a feature in AI Chat Exporter that solves this problem. It extracts a conversation from any of 18 supported platforms, strips out visual elements that cannot transfer (images, embeds), reformats the remaining text as a structured continuation prompt, and opens the target AI platform with the conversation ready to paste. The target AI receives the full conversation history with clear user/assistant role markers, allowing it to pick up where the last platform left off.</p>
+      <p>No other browser extension, plugin, or tool offers this capability. It is unique to AI Chat Exporter.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Supported Platforms</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Source (Export From)</th>
+              <th>Target (Continue On)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>All 18 supported platforms</td>
+              <td>ChatGPT, Claude, Gemini, DeepSeek, Perplexity, Qwen, Mistral, NotebookLM, Copilot, Meta AI, Z.AI, AI Studio, Lumo, Joyland, Chub</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The source can be any of the 17 platforms that AI Chat Exporter supports. The target list covers 15 platforms where you can continue the conversation. Not every source-target combination is equally useful&mdash;some platforms handle long context better than others&mdash;but the transfer itself works in every case.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>How It Works</h2>
+      <div class="steps">
+        <div class="step">
+          <div class="step-number">1</div>
+          <div class="step-content">
+            <h3>Extract the Conversation</h3>
+            <p>Open the source conversation in your browser. AI Chat Exporter reads the page DOM and extracts all messages with their roles (user or assistant) and content. Code blocks, text formatting, and structured content are preserved.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">2</div>
+          <div class="step-content">
+            <h3>Strip Non-Transferable Elements</h3>
+            <p>Images, embedded media, file uploads, and platform-specific UI elements are stripped from the conversation. These elements cannot be meaningfully transferred between platforms because each AI handles media differently. The text content and code are preserved.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">3</div>
+          <div class="step-content">
+            <h3>Format as Continuation Prompt</h3>
+            <p>The conversation is reformatted with clear role markers. User messages are prefixed and assistant responses are clearly delimited. The result is a structured prompt that the target AI can parse as a multi-turn conversation rather than a raw text dump.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">4</div>
+          <div class="step-content">
+            <h3>Open Target Platform</h3>
+            <p>The extension stores the formatted conversation in <code>chrome.storage</code> as a pending continuation and opens the target platform in a new tab. When the platform loads, the conversation content is ready to paste into the chat input as your first message, giving the AI the full context.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Use Cases</h2>
+      <div class="features-grid">
+        <div class="feature-card">
+          <h3>Hit Platform Limits</h3>
+          <p>ChatGPT hit its message limit or Claude reached its context window? Transfer the conversation to another platform and keep working. No progress lost, no need to re-explain the context from scratch.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Compare AI Responses</h3>
+          <p>Ask the same question across multiple platforms and compare their answers. Transfer a conversation from ChatGPT to Claude to see how Claude handles the same coding problem. Transfer to Gemini to leverage its longer context window.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Platform-Specific Strengths</h3>
+          <p>Use ChatGPT for creative brainstorming, then transfer the ideas to Claude for structured analysis. Start a research thread on Perplexity for citations, then move it to Gemini for deeper synthesis with its larger context.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Backup Before Deletion</h3>
+          <p>Some platforms delete conversations after inactivity or when you clear your history. Transfer important conversations to a persistent platform or export them as a file before they disappear.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Long-Context Migration</h3>
+          <p>Gemini and Claude support very large context windows. Transfer a long conversation from a platform with smaller limits to one that can handle the full history without truncation.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Team Collaboration</h3>
+          <p>Your teammate uses Claude but you prefer ChatGPT. Transfer a conversation between platforms so both of you can work on the same thread using your preferred AI tool.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Transfer Workflow: ChatGPT to Claude</h2>
+      <p>Here is a concrete example of transferring a coding conversation from ChatGPT to Claude:</p>
+      <ol>
+        <li>You have been debugging a React component in ChatGPT. The conversation is 30 messages deep with code snippets, error logs, and solutions.</li>
+        <li>ChatGPT starts giving shorter responses as it approaches its context limit.</li>
+        <li>Click the AI Chat Exporter icon while on the ChatGPT tab. Select "Continue on Claude" from the cross-AI transfer menu.</li>
+        <li>The extension extracts the conversation, strips the screenshots you pasted earlier, formats the remaining text and code with clear role markers, and stores it as a pending continuation.</li>
+        <li>A new tab opens to claude.ai. Start a new conversation and paste the content. Claude receives the full 30-message history with proper formatting and picks up the debugging session seamlessly.</li>
+      </ol>
+      <p>The same workflow works in reverse. Start on Claude, transfer to ChatGPT. Or start on DeepSeek, transfer to Gemini. The transfer is platform-agnostic.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Limitations and Trade-offs</h2>
+      <p>Cross-AI Transfer is powerful but not magic. Here is what you should expect:</p>
+      <div class="callout callout-info">
+        <strong>Images are stripped.</strong> Screenshots, uploaded files, and generated images cannot be transferred between platforms. Each AI platform handles images differently, and there is no standard format for transferring visual content in conversation context. Text descriptions of images are preserved where the AI included them in its response.
+      </div>
+      <div class="callout callout-info">
+        <strong>Formatting is simplified.</strong> Complex rich text formatting (colored text, custom fonts, embedded widgets) is reduced to standard Markdown. This is necessary because target platforms only accept plain text input.
+      </div>
+      <div class="callout callout-info">
+        <strong>Platform-specific features are lost.</strong> ChatGPT Canvas documents, Claude Artifacts, and Gemini code execution outputs cannot transfer as live features. Claude Artifacts and Gemini code execution content are reduced to their text representation. ChatGPT Canvas documents are represented by a labeled placeholder showing the document title, since Canvas previews cannot be re-embedded. Regardless, the main conversation text transfers cleanly.
+      </div>
+      <p>Despite these limitations, the core value is preserved: the full conversation text, code blocks, and structured content transfer cleanly. For most conversations, the text content is what matters.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Technical Details</h2>
+      <p>For developers who are curious about the implementation:</p>
+      <ul>
+        <li><strong>Storage mechanism:</strong> The formatted conversation is stored in <code>chrome.storage.session</code> (or <code>browser.storage.session</code> on Firefox) as a <code>pendingContinuation</code> object. This is temporary storage that persists until the target tab is loaded.</li>
+        <li><strong>Role markers:</strong> Messages are delimited with <code>[User]</code> and <code>[Assistant]</code> prefixes. This format is widely recognized by LLM chat interfaces and helps the target AI understand the conversation structure.</li>
+        <li><strong>Image handling:</strong> The extension detects <code>&lt;img&gt;</code> elements and base64 data URIs in the conversation DOM and strips them. Alt text is preserved where available, giving the target AI a textual description of visual content.</li>
+        <li><strong>Size limits:</strong> The transfer format is plain text, so extremely long conversations may exceed the target platform's input limits. The extension includes the full conversation as-is; if a chat exceeds the platform's limit, the target AI will typically accept only the recent portion. For typical conversations the full history transfers cleanly.</li>
+      </ul>
+    </section>
+
+    <section class="content-section">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq">
+        <div class="faq-item">
+          <button class="faq-question">How do I transfer a conversation from one AI to another?</button>
+          <div class="faq-answer">
+            <p>Open the conversation you want to transfer in your browser. Click the AI Chat Exporter extension icon and select the cross-AI transfer option. Choose your target platform from the list. The extension extracts the conversation, formats it, and opens the target platform in a new tab. Paste the content into the chat input to continue the conversation.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Will it keep my entire chat history?</button>
+          <div class="faq-answer">
+            <p>Yes. The extension extracts the full conversation as displayed in the browser. The transfer is formatted as plain text, so if the conversation is extremely long and the target platform has input limits, the target AI may only ingest the recent portion within its window. For typical conversations (under 50 messages), the full history transfers cleanly.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Does it work with all 18 supported platforms?</button>
+          <div class="faq-answer">
+            <p>You can export from any of the 18 supported platforms. Cross-AI transfer targets 15 platforms where you can continue the conversation. All major platforms are covered: ChatGPT, Claude, Gemini, DeepSeek, Perplexity, Copilot, and more.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">What happens to images in the conversation?</button>
+          <div class="faq-answer">
+            <p>Images are stripped during transfer because each AI platform handles visual content differently and there is no standard format for embedding images in text-based chat input. Text descriptions that the AI generated (such as "as shown in the image above") are preserved in the transfer.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Can I transfer from Claude to ChatGPT?</button>
+          <div class="faq-answer">
+            <p>Yes. Cross-AI transfer works in any direction. Export from Claude and continue on ChatGPT, or export from ChatGPT and continue on Claude. The same applies to all supported source and target combinations.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Is there a size limit for transferred conversations?</button>
+          <div class="faq-answer">
+            <p>There is no hard limit imposed by the extension. The transfer is plain text, so target platforms with their own input length limits may ignore content beyond their window. Short to medium conversations transfer in full; for extremely long chats, the most recent context is what the target platform focuses on.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Does this require API keys or accounts on both platforms?</button>
+          <div class="faq-answer">
+            <p>No API keys are needed. The extension reads conversations from the browser page and opens the target platform in a new tab. You need active accounts on both the source and target platforms, but the extension itself requires no API access.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="chatgpt-exporter.html" class="related-link">
+          <h3>ChatGPT Exporter</h3>
+          <p>Export ChatGPT conversations to Markdown, PDF, JSON, and all other formats.</p>
+        </a>
+        <a href="claude-exporter.html" class="related-link">
+          <h3>Claude Exporter</h3>
+          <p>Export Claude conversations with Artifacts, Thinking blocks, and tool use.</p>
+        </a>
+        <a href="gemini-exporter.html" class="related-link">
+          <h3>Gemini Exporter</h3>
+          <p>Export Google Gemini conversations with full context and formatting.</p>
+        </a>
+        <a href="ai-chat-backup.html" class="related-link">
+          <h3>AI Chat Backup</h3>
+          <p>Archive your conversations as structured Markdown or JSON files.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <div class="callout callout-success">
+        <strong>Stop being locked into a single AI platform.</strong> Install AI Chat Exporter and move freely between ChatGPT, Claude, Gemini, and every other AI. Your conversations belong to you.
+        <div class="cta-group">
+          <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+          <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/css/seo-pages.css
+++ b/docs/css/seo-pages.css
@@ -164,6 +164,15 @@ h1 {
   margin-top: 24px;
 }
 
+.cta-group.compact {
+  margin-top: 1rem;
+}
+
+.md-preview {
+  margin: 0;
+  overflow-x: auto;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;

--- a/docs/css/seo-pages.css
+++ b/docs/css/seo-pages.css
@@ -1,0 +1,508 @@
+/* AI Chat Exporter — SEO Pages Shared Styles */
+/* Matches existing site dark theme (Outfit font, #0b111e base) */
+
+:root {
+  --bg-base: #0b111e;
+  --bg-surface: rgba(19, 30, 49, 0.6);
+  --bg-surface-hover: rgba(30, 48, 77, 0.8);
+  --bg-code: rgba(15, 23, 42, 0.8);
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --color-primary: #3b82f6;
+  --color-primary-glow: rgba(59, 130, 246, 0.15);
+  --color-success: #10b981;
+  --color-warning: #f59e0b;
+  --color-accent: #8b5cf6;
+  --border-color: rgba(148, 163, 184, 0.08);
+  --border-hover: rgba(148, 163, 184, 0.2);
+  --font-sans: 'Outfit', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  --max-width: 860px;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg-base);
+  color: var(--text-primary);
+  line-height: 1.7;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: '';
+  position: absolute;
+  top: -10%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100vw;
+  height: 60vh;
+  background: radial-gradient(circle, rgba(59,130,246,0.06) 0%, rgba(11,17,30,0) 70%);
+  z-index: -1;
+  pointer-events: none;
+}
+
+/* ── Header ── */
+header {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.logo-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+.logo-img { width: 32px; height: 32px; border-radius: 8px; }
+
+.logo-text {
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, #fff 0%, #cbd5e1 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.nav-links { display: flex; gap: 10px; align-items: center; }
+
+.nav-link {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--text-primary);
+  border-color: var(--border-hover);
+  background: rgba(255,255,255,0.04);
+}
+
+/* ── Breadcrumb ── */
+.breadcrumb {
+  max-width: var(--max-width);
+  margin: 24px auto 0;
+  padding: 0 20px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.breadcrumb a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover { text-decoration: underline; }
+
+.breadcrumb span { margin: 0 6px; }
+
+/* ── Main Content ── */
+main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 40px 20px 80px;
+}
+
+/* ── Hero ── */
+.hero { margin-bottom: 48px; }
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  background: rgba(59,130,246,0.1);
+  padding: 5px 14px;
+  border-radius: 20px;
+  margin-bottom: 16px;
+  border: 1px solid rgba(59,130,246,0.15);
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  margin-bottom: 16px;
+  background: linear-gradient(to right, #ffffff, #93c5fd);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  max-width: 640px;
+  line-height: 1.6;
+}
+
+/* ── CTA Buttons ── */
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  border: 1px solid var(--border-color);
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, rgba(59,130,246,0.15), rgba(59,130,246,0.05));
+  border-color: rgba(59,130,246,0.3);
+  color: #8ab4f8;
+}
+
+.btn-primary:hover {
+  background: linear-gradient(135deg, rgba(59,130,246,0.25), rgba(59,130,246,0.1));
+  border-color: rgba(59,130,246,0.5);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 20px rgba(59,130,246,0.15);
+}
+
+.btn-secondary {
+  background: rgba(255,255,255,0.03);
+  color: var(--text-secondary);
+}
+
+.btn-secondary:hover {
+  background: rgba(255,255,255,0.06);
+  color: var(--text-primary);
+  border-color: var(--border-hover);
+}
+
+/* ── Section headings ── */
+h2 {
+  font-size: 1.6rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 48px 0 20px;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 10px;
+}
+
+h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 28px 0 12px;
+  color: var(--text-primary);
+}
+
+p { margin-bottom: 16px; color: var(--text-secondary); font-size: 1.02rem; }
+
+.content-section { margin-bottom: 8px; }
+
+ul, ol {
+  margin-bottom: 16px;
+  padding-left: 24px;
+  color: var(--text-secondary);
+}
+
+li { margin-bottom: 8px; }
+li strong { color: var(--text-primary); }
+
+/* ── Feature Cards ── */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  margin: 24px 0 32px;
+}
+
+.feature-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  padding: 24px;
+  border-radius: 14px;
+  transition: all 0.2s ease;
+}
+
+.feature-card:hover {
+  border-color: var(--border-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+}
+
+.feature-card h4 {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: var(--text-primary);
+}
+
+.feature-card p {
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+  margin-bottom: 0;
+  line-height: 1.5;
+}
+
+/* ── Tables ── */
+.table-wrapper {
+  overflow-x: auto;
+  margin: 20px 0 32px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+thead {
+  background: rgba(59,130,246,0.08);
+}
+
+th {
+  padding: 12px 16px;
+  text-align: left;
+  font-weight: 700;
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-color);
+  white-space: nowrap;
+}
+
+td {
+  padding: 10px 16px;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+tr:last-child td { border-bottom: none; }
+
+tr:hover td { background: rgba(255,255,255,0.02); }
+
+/* ── Steps / Workflow ── */
+.steps {
+  counter-reset: step;
+  margin: 24px 0 32px;
+}
+
+.step {
+  counter-increment: step;
+  display: flex;
+  gap: 16px;
+  margin-bottom: 20px;
+  padding: 20px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+}
+
+.step::before {
+  content: counter(step);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(59,130,246,0.15);
+  color: var(--color-primary);
+  font-weight: 800;
+  font-size: 0.95rem;
+  flex-shrink: 0;
+}
+
+.step-content h4 {
+  font-size: 1.02rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+  color: var(--text-primary);
+}
+
+.step-content p {
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+  margin-bottom: 0;
+}
+
+/* ── Callout / Info Box ── */
+.callout {
+  padding: 20px 24px;
+  border-radius: 12px;
+  margin: 24px 0;
+  border-left: 4px solid;
+}
+
+.callout-info {
+  background: rgba(59,130,246,0.06);
+  border-color: var(--color-primary);
+}
+
+.callout-success {
+  background: rgba(16,185,129,0.06);
+  border-color: var(--color-success);
+}
+
+.callout-warning {
+  background: rgba(245,158,11,0.06);
+  border-color: var(--color-warning);
+}
+
+.callout p { margin-bottom: 0; }
+.callout strong { color: var(--text-primary); }
+
+/* ── FAQ ── */
+.faq { margin: 48px 0; }
+
+.faq-item {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+
+.faq-question {
+  width: 100%;
+  padding: 16px 20px;
+  background: var(--bg-surface);
+  border: none;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: background 0.2s ease;
+}
+
+.faq-question:hover { background: var(--bg-surface-hover); }
+
+.faq-question::after {
+  content: '+';
+  font-size: 1.3rem;
+  color: var(--color-primary);
+  transition: transform 0.2s ease;
+}
+
+.faq-item.open .faq-question::after { content: '−'; }
+
+.faq-answer {
+  padding: 0 20px;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+}
+
+.faq-item.open .faq-answer {
+  padding: 0 20px 16px;
+  max-height: 600px;
+}
+
+.faq-answer p {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+/* ── Related Pages ── */
+.related-pages {
+  margin: 48px 0 0;
+  padding: 28px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+}
+
+.related-pages h3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-size: 1.1rem;
+}
+
+.related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+.related-link {
+  display: block;
+  padding: 10px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--color-primary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.related-link:hover {
+  background: rgba(59,130,246,0.08);
+  border-color: rgba(59,130,246,0.3);
+}
+
+/* ── Footer ── */
+footer {
+  max-width: 1100px;
+  margin: 0 auto;
+  border-top: 1px solid var(--border-color);
+  padding: 32px 20px;
+  text-align: center;
+  font-size: 0.88rem;
+  color: var(--text-muted);
+}
+
+footer a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+footer a:hover { color: var(--text-primary); }
+
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  h1 { font-size: 1.9rem; }
+  h2 { font-size: 1.35rem; }
+  .features-grid { grid-template-columns: 1fr; }
+  .step { flex-direction: column; gap: 10px; }
+  header { flex-direction: column; gap: 12px; }
+  .nav-links { flex-wrap: wrap; justify-content: center; }
+  .cta-group { flex-direction: column; }
+  .btn { justify-content: center; }
+}

--- a/docs/deepseek-exporter.html
+++ b/docs/deepseek-exporter.html
@@ -119,6 +119,11 @@
             <td>Social media, quick screenshots, sharing</td>
             <td>Rendered in image</td>
           </tr>
+          <tr>
+            <td><strong>Continuation</strong></td>
+            <td>Transfer to another AI platform or PKM app</td>
+            <td>Included as text</td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -253,8 +258,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/deepseek-exporter.html
+++ b/docs/deepseek-exporter.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DeepSeek Exporter — Export DeepSeek Conversations to Markdown &amp; More</title>
+  <meta name="description" content="Export DeepSeek conversations to Markdown, PDF, JSON, HTML, Word and PNG. Preserves thinking blocks and code. Free, open-source extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/deepseek-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/deepseek-exporter.html" />
+  <meta property="og:title" content="DeepSeek Exporter — Export DeepSeek Conversations to Markdown &amp; More" />
+  <meta property="og:description" content="Export DeepSeek conversations to Markdown, PDF, JSON, HTML, Word and PNG. Preserves thinking blocks and code. Free, open-source extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>›</span> DeepSeek Exporter</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Supports Thinking Blocks</span>
+      <h1>DeepSeek Exporter — Save Your DeepSeek Chats</h1>
+      <p class="hero-subtitle">Export DeepSeek conversations with reasoning blocks, code, and formatting intact. Choose from seven output formats. Everything runs locally in your browser.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <h2>Why Export DeepSeek Conversations</h2>
+    <p>DeepSeek does not offer a built-in export feature for conversations. Once you close a chat or clear your history, the content is gone. Researchers, developers, and prompt engineers use DeepSeek daily for complex reasoning tasks, code generation, and multi-turn analysis. Losing those conversations means losing work.</p>
+    <p>DeepSeek is also distinct from other AI platforms because of its reasoning model. DeepSeek-R1 produces visible thinking blocks that show the model's step-by-step reasoning process. These blocks are valuable for understanding how the model arrived at an answer, debugging chain-of-thought prompts, and documenting research methodology. Most generic chat exporters strip or mangle these blocks entirely.</p>
+
+    <h2>DeepSeek-Specific Parsing</h2>
+    <p>AI Chat Exporter includes a dedicated parser built specifically for DeepSeek's DOM structure. The parser understands the difference between regular assistant messages and the reasoning blocks that DeepSeek-R1 displays in its collapsible thinking sections.</p>
+    <div class="features-grid">
+      <div class="feature-card">
+        <h4>Thinking Block Extraction</h4>
+        <p>Reasoning blocks are extracted with clear labels and preserved in the output. In Markdown, they appear as blockquotes with a "Thinking" prefix. In JSON, they are tagged with a dedicated <code>type: "thinking"</code> field.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Code Block Preservation</h4>
+        <p>DeepSeek's code blocks retain their language tags and syntax structure. Exported code fences include the correct language identifier for syntax highlighting in editors and documentation tools.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Multi-Turn Context</h4>
+        <p>Full conversation threads are captured in order, including user messages, assistant responses, and all thinking blocks. No messages are skipped regardless of conversation length.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Math Rendering</h4>
+        <p>LaTeX expressions embedded in DeepSeek responses are preserved as-is, making exported files compatible with tools that render math notation like Obsidian, Jupyter, or Overleaf.</p>
+      </div>
+    </div>
+
+    <h2>Seven Export Formats</h2>
+    <p>Every DeepSeek conversation can be exported in any of the following formats. Choose the one that fits your workflow.</p>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Format</th>
+            <th>Best For</th>
+            <th>Thinking Blocks</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Markdown</strong></td>
+            <td>Documentation, Obsidian, GitHub wikis</td>
+            <td>Blockquoted with label</td>
+          </tr>
+          <tr>
+            <td><strong>JSON</strong></td>
+            <td>Programmatic processing, APIs, data pipelines</td>
+            <td>Tagged type field</td>
+          </tr>
+          <tr>
+            <td><strong>HTML</strong></td>
+            <td>Web archives, sharing, readable backups</td>
+            <td>Collapsible details element</td>
+          </tr>
+          <tr>
+            <td><strong>PDF</strong></td>
+            <td>Printed records, formal documentation</td>
+            <td>Preserved with formatting</td>
+          </tr>
+          <tr>
+            <td><strong>Word (.doc)</strong></td>
+            <td>Collaboration, editing in Microsoft Word</td>
+            <td>Preserved with styling</td>
+          </tr>
+          <tr>
+            <td><strong>PNG Image</strong></td>
+            <td>Social media, quick screenshots, sharing</td>
+            <td>Rendered in image</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>DeepSeek Exporter vs Manual Copy-Paste</h2>
+    <p>Copying and pasting a DeepSeek conversation manually loses critical structure. Here is what you miss without a proper exporter.</p>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Aspect</th>
+            <th>Manual Copy-Paste</th>
+            <th>AI Chat Exporter</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Thinking blocks</td>
+            <td>Usually collapsed and skipped</td>
+            <td>Fully extracted and labeled</td>
+          </tr>
+          <tr>
+            <td>Code formatting</td>
+            <td>Lost indentation and language tags</td>
+            <td>Preserved with syntax markers</td>
+          </tr>
+          <tr>
+            <td>Message roles</td>
+            <td>No distinction between user and assistant</td>
+            <td>Clearly labeled speaker tags</td>
+          </tr>
+          <tr>
+            <td>Timestamps</td>
+            <td>Not captured</td>
+            <td>Included where available</td>
+          </tr>
+          <tr>
+            <td>Batch export</td>
+            <td>One conversation at a time</td>
+            <td>One click per conversation</td>
+          </tr>
+          <tr>
+            <td>Output formats</td>
+            <td>Plain text only</td>
+            <td>Seven formats to choose from</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>How to Export a DeepSeek Conversation</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-content">
+          <h4>Install the Extension</h4>
+          <p>Add AI Chat Exporter from the Chrome Web Store or Firefox Add-ons. The extension works on Edge as well through the Chrome store.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Open Your DeepSeek Chat</h4>
+          <p>Navigate to chat.deepseek.com and open the conversation you want to export. The extension detects DeepSeek's DOM automatically.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Click the Extension Icon</h4>
+          <p>Click the AI Chat Exporter icon in your browser toolbar. A popup appears with export options for the current conversation.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Choose Your Format and Export</h4>
+          <p>Select Markdown, JSON, HTML, PDF, Word, or PNG. The file downloads immediately. No accounts, no cloud uploads, no data leaves your machine.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout callout-info">
+      <p><strong>Privacy note:</strong> AI Chat Exporter runs entirely in your browser. No conversation data is sent to any server. The extension has no analytics, no telemetry, and no backend. Your DeepSeek conversations never leave your device.</p>
+    </div>
+
+    <div class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">Does it export DeepSeek thinking blocks?</button>
+        <div class="faq-answer">
+          <p>Yes. DeepSeek-R1 reasoning and thinking blocks are fully extracted and preserved in the export. In Markdown output they appear as clearly labeled blockquotes. In JSON they are tagged with a dedicated type field so you can filter or process them programmatically.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I export specific messages from a conversation?</button>
+        <div class="faq-answer">
+          <p>The extension exports the entire currently visible conversation. To export a subset, start a new DeepSeek chat containing only the messages you need, then export that conversation. This is the most reliable way to capture exactly what you want.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">What formats are supported for DeepSeek export?</button>
+        <div class="faq-answer">
+          <p>All major formats are supported: Markdown, JSON, HTML, PDF, Word (.doc), PNG image, and Continuation. Choose the format that matches your use case from the extension popup.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Does it work with DeepSeek API responses?</button>
+        <div class="faq-answer">
+          <p>AI Chat Exporter works on the DeepSeek web interface at chat.deepseek.com. It does not interact with the DeepSeek API directly. To export API responses, use the JSON export format on conversations that include API-generated content displayed in the chat UI.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Is AI Chat Exporter free?</button>
+        <div class="faq-answer">
+          <p>Yes. AI Chat Exporter is completely free and open source under the Mozilla Public License 2.0. There are no premium tiers, no subscription fees, and no hidden costs. You can verify this by reviewing the source code on GitHub.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="related-pages">
+      <h3>Other Exporters You Might Need</h3>
+      <div class="related-grid">
+        <a href="chatgpt-exporter.html" class="related-link">ChatGPT Exporter</a>
+        <a href="claude-exporter.html" class="related-link">Claude Exporter</a>
+        <a href="markdown-exporter.html" class="related-link">Markdown Exporter</a>
+      </div>
+    </div>
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/gemini-exporter.html
+++ b/docs/gemini-exporter.html
@@ -242,8 +242,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/gemini-exporter.html
+++ b/docs/gemini-exporter.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gemini Exporter — Export Google Gemini Conversations to Markdown, PDF & More</title>
+  <meta name="description" content="Export Google Gemini conversations to Markdown, PDF, JSON, HTML, Word and PNG. Handles Deep Research sessions and code. Free, open-source." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/gemini-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/gemini-exporter.html" />
+  <meta property="og:title" content="Gemini Exporter — Export Google Gemini Conversations to Markdown, PDF & More" />
+  <meta property="og:description" content="Export Google Gemini conversations to Markdown, PDF, JSON, HTML, Word and PNG. Handles Deep Research sessions and code. Free, open-source." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>&rsaquo;</span> Gemini Exporter</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Supports Deep Research</span>
+      <h1>Gemini Exporter &mdash; Save Your Gemini Chats</h1>
+      <p class="hero-subtitle">Export your Google Gemini conversations to Markdown, PDF, JSON, HTML, Word, and PNG. Code blocks, tables, images, and long Deep Research sessions are all captured in one click.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <h2>Why Export Gemini Conversations?</h2>
+    <p>Google Gemini is an increasingly powerful AI assistant that integrates deeply with Google's ecosystem. It handles text, code, and images, and its Deep Research feature produces long, multi-source analyses. But Gemini does not offer a native export or download feature for conversations.</p>
+    <p>This means that valuable research threads, code generation sessions, and creative outputs are effectively trapped within Gemini's interface. If you need to reference a previous conversation, share findings with a colleague, or archive important exchanges, you are limited to screenshotting or manual copy-paste&mdash;both of which lose formatting, code highlighting, and structure.</p>
+    <p>The Gemini Exporter feature in AI Chat Exporter solves this by reading the Gemini DOM directly in your browser and converting conversations into properly formatted, portable files. Everything runs locally in the extension, with zero data transmission.</p>
+
+    <h2>Gemini-Specific Features</h2>
+    <div class="features-grid">
+      <div class="feature-card">
+        <h4>Deep Research Sessions</h4>
+        <p>Gemini's Deep Research feature produces long, multi-source analysis. The exporter handles these extended conversations without truncation, preserving the full research output with source references.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Code Block Preservation</h4>
+        <p>All code blocks are exported with their language tags intact. Syntax highlighting works in any Markdown editor that supports it, and multi-part code output is preserved as separate fenced blocks.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Image Handling</h4>
+        <p>Images uploaded by you or generated by Gemini are captured and embedded in the export as data URIs in Markdown and HTML, and inline in PDF and Word formats.</p>
+      </div>
+      <div class="feature-card">
+        <h4>One-Click Export</h4>
+        <p>Click the extension popup or side panel and Gemini conversations convert to your chosen format instantly&mdash;no copying, no pasting, no cleanup.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Obsidian &amp; Logseq Ready</h4>
+        <p>Markdown output works directly in Obsidian, Logseq, Notion, Bear, and any Markdown editor. Math and code render correctly across all of them.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Six Export Formats</h4>
+        <p>Choose from Markdown, PDF, JSON, HTML, Word, or PNG. Each format is optimized for different use cases, from developer pipelines to visual sharing.</p>
+      </div>
+    </div>
+
+    <h2>Supported Export Formats</h2>
+    <p>AI Chat Exporter provides six output formats for Gemini conversations, each tailored to different needs:</p>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Format</th>
+            <th>Code</th>
+            <th>Tables</th>
+            <th>Images</th>
+            <th>Best For</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Markdown (.md)</strong></td>
+            <td>Language-tagged fences</td>
+            <td>Preserved</td>
+            <td>Data URIs</td>
+            <td>Note-taking, Obsidian</td>
+          </tr>
+          <tr>
+            <td><strong>PDF (.pdf)</strong></td>
+            <td>Syntax colored</td>
+            <td>Preserved</td>
+            <td>Inline images</td>
+            <td>Printing, archival</td>
+          </tr>
+          <tr>
+            <td><strong>JSON (.json)</strong></td>
+            <td>Plain text</td>
+            <td>Structured</td>
+            <td>Base64</td>
+            <td>Developers, pipelines</td>
+          </tr>
+          <tr>
+            <td><strong>HTML (.html)</strong></td>
+            <td>Highlighted</td>
+            <td>Preserved</td>
+            <td>Inline &lt;img&gt;</td>
+            <td>Web archival</td>
+          </tr>
+          <tr>
+            <td><strong>Word (.doc)</strong></td>
+            <td>Monospace blocks</td>
+            <td>Preserved</td>
+            <td>Embedded</td>
+            <td>Documents, sharing</td>
+          </tr>
+          <tr>
+            <td><strong>PNG (.png)</strong></td>
+            <td>Highlighted</td>
+            <td>Rendered</td>
+            <td>Captured</td>
+            <td>Social, presentations</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>How Gemini DOM Extraction Works</h2>
+    <p>AI Chat Exporter reads Gemini conversations by inspecting the page's DOM structure. When you trigger an export, the extension traverses the conversation elements in the active Gemini tab, identifies user and assistant message boundaries, and extracts the content including formatted text, code blocks, and links.</p>
+    <p>For Deep Research sessions, the extension uses a dedicated immersive-panel extraction path that captures the full research output as structured messages rather than a block of raw text.</p>
+    <p>All extraction happens locally. The extension makes no requests to Google's servers, our servers, or any third-party API. The DOM parsing runs entirely within the browser's extension sandbox, ensuring your conversation data never leaves your machine.</p>
+
+    <div class="callout callout-warning">
+      <p><strong>DOM-dependent updates:</strong> Since the exporter reads Gemini's DOM structure, major UI redesigns by Google may temporarily affect extraction. The extension is updated regularly to track DOM changes. If an export fails after a Gemini UI update, check for extension updates or report the issue on GitHub.</p>
+    </div>
+
+    <h2>No Official Gemini Export&mdash;Until Now</h2>
+    <p>Unlike ChatGPT, which offers a data export feature, Google Gemini currently has no built-in way to export or download individual conversation content. This means Gemini users have been limited to:</p>
+    <ul>
+      <li><strong>Manual copy-paste</strong> &mdash; tedious for long conversations, loses code formatting and images</li>
+      <li><strong>Screenshots</strong> &mdash; non-searchable, low resolution, cannot be linked or tagged</li>
+      <li><strong>Google Takeout</strong> &mdash; exports raw data in a bulk archive, not individual conversations in readable formats</li>
+    </ul>
+    <p>AI Chat Exporter provides what Google has not: a fast, one-click way to save Gemini conversations in formats you actually use. The extension bridges the gap between Gemini's powerful AI capabilities and the practical need to preserve and share conversation outputs.</p>
+
+    <h2>A Closer Look at Deep Research Exports</h2>
+    <p>Gemini's Deep Research mode generates detailed reports built from many sources. Exporting these sessions preserves the full analysis, including:</p>
+    <ul>
+      <li><strong>Comprehensive findings</strong> &mdash; The full research report is exported with its structure, headings, and reasoning intact.</li>
+      <li><strong>Source references</strong> &mdash; Citations and linked sources are preserved so you can trace claims.</li>
+      <li><strong>Reusable formats</strong> &mdash; Save as Markdown for note-taking, PDF for sharing, or JSON for programmatic use.</li>
+    </ul>
+
+    <div class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">Does this work with Gemini's Deep Research feature?</button>
+        <div class="faq-answer"><p>Yes. Deep Research sessions produce long, multi-source analyses that the exporter handles without truncation, using a dedicated immersive-panel extraction path. The full research output, including source references and structured findings, is captured in the export.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Are code blocks preserved in the export?</button>
+        <div class="faq-answer"><p>Yes. Code blocks are extracted with their language tags and exported as fenced code blocks in Markdown, highlighted blocks in HTML, monospace blocks in Word, and plain text in JSON. They also render correctly in PNG output.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Are images from Gemini conversations preserved?</button>
+        <div class="faq-answer"><p>Yes. Both user-uploaded images and Gemini-generated images are captured and embedded in the export. In Markdown and HTML formats, images appear as base64 data URIs. In PDF and Word formats, they are inline embedded images.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I export Gemini conversations to Obsidian?</button>
+        <div class="faq-answer"><p>Yes. Export in Markdown format and your Gemini conversations work directly in Obsidian, or use the extension's built-in Obsidian transfer to send them straight to your vault.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Is my Gemini data sent to any external server?</button>
+        <div class="faq-answer"><p>No. All extraction and formatting happens locally within your browser extension. The extension never contacts Google's servers, our servers, or any third-party API. You can verify this by inspecting the source code on GitHub.</p></div>
+      </div>
+    </div>
+
+    <div class="related-pages">
+      <h3>Related Guides</h3>
+      <div class="related-grid">
+        <a href="gemini-to-markdown.html" class="related-link">Gemini to Markdown</a>
+        <a href="chatgpt-exporter.html" class="related-link">ChatGPT Exporter</a>
+        <a href="claude-exporter.html" class="related-link">Claude Exporter</a>
+      </div>
+    </div>
+
+    <h2>How to Export Gemini Conversations</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-content">
+          <h4>Install the Extension</h4>
+          <p>Add AI Chat Exporter from the Chrome Web Store or Firefox Add-ons. The extension requires minimal permissions&mdash;only access to the AI platform tabs you want to export from.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Open a Gemini Conversation</h4>
+          <p>Navigate to gemini.google.com and open any conversation you want to export. Works with regular chats and Deep Research outputs.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Click the Export Button</h4>
+          <p>Open the extension popup or side panel and select your preferred format. The extension reads the conversation from the page and generates the output file.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Save or Transfer</h4>
+          <p>The file downloads automatically. Use the Obsidian transfer for direct vault integration, or copy the content to your clipboard for pasting into another application.</p>
+        </div>
+      </div>
+    </div>
+
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/gemini-to-markdown.html
+++ b/docs/gemini-to-markdown.html
@@ -161,8 +161,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/gemini-to-markdown.html
+++ b/docs/gemini-to-markdown.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gemini to Markdown — Export Google Gemini Chats as .md Files</title>
+  <meta name="description" content="Convert Google Gemini conversations to clean Markdown. Preserves Deep Research sessions, code blocks, tables, and images. Free extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/gemini-to-markdown.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/gemini-to-markdown.html" />
+  <meta property="og:title" content="Gemini to Markdown — Export Google Gemini Chats as .md Files" />
+  <meta property="og:description" content="Convert Google Gemini conversations to clean Markdown. Preserves Deep Research sessions, code blocks, tables, and images. Free extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>&rsaquo;</span> <a href="gemini-exporter.html">Gemini Exporter</a> <span>&rsaquo;</span> Gemini to Markdown</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Supports Deep Research</span>
+      <h1>Gemini to Markdown &mdash; Structured Chat Exports</h1>
+      <p class="hero-subtitle">Convert your Google Gemini conversations into clean, portable Markdown files. Deep Research reports, code blocks, tables, and images are all preserved.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <h2>Why Markdown for Gemini Conversations?</h2>
+    <p>Markdown is the most versatile format for preserving AI conversation content. It is plain text, meaning it works in any text editor, version control system, or note-taking app. Unlike proprietary formats like Word or PDF, Markdown files will remain readable and editable decades from now.</p>
+    <p>For Gemini conversations specifically, Markdown is an excellent match because Gemini already formats its responses using Markdown conventions. Headings, code blocks, bullet lists, bold text, and tables all convert directly without lossy transformation. The exporter preserves this structure faithfully.</p>
+    <p>Markdown output also integrates seamlessly with developer workflows. Import exported conversations into Jupyter notebooks, paste them into GitHub issues, use them as context in AI coding assistants, or store them in your personal knowledge base. The format is universally understood.</p>
+
+    <h2>Deep Research Report Exports</h2>
+    <p>Gemini's Deep Research feature produces comprehensive, multi-source reports. The exporter recognizes Deep Research sessions through Gemini's immersive panel structure and converts them into well-structured Markdown with the report content intact.</p>
+    <p>Within a research report, headings, source references, findings, and the research question are preserved in the Markdown output. You can save the full report as a standalone .md file and reference it later without re-opening the conversation in Gemini.</p>
+    <p>Because the exporter handles the immersive-panel layout via a dedicated extraction path, Deep Research exports come out clean&mdash;without leftover UI chrome, navigation elements, or duplicated prompts.</p>
+
+    <h2>Code Block Preservation</h2>
+    <p>Gemini frequently generates code in its responses, from simple scripts to complete applications. The exporter preserves every code block with its language identifier, ensuring syntax highlighting works correctly when you open the Markdown file in any code-aware editor.</p>
+    <p>Language detection uses Gemini's own code fence annotations. When Gemini wraps code in triple backticks with a language tag like <code>python</code> or <code>javascript</code>, that tag is preserved in the export. Inline code and backtick-wrapped terms are also preserved, maintaining the distinction between inline references and full code blocks.</p>
+
+    <h2>Tables and Lists</h2>
+    <p>Gemini responses frequently include Markdown tables and nested lists. The exporter preserves both faithfully. Tables keep their alignment, column headers, and cell content; lists retain their nesting and ordering&mdash;important for step-by-step instructions Google often generates.</p>
+    <p>Blockquotes, horizontal rules, and footnotes also carry over, so the export reads exactly like the conversation you saw on screen.</p>
+
+    <h2>Image Embedding</h2>
+    <p>Images in Gemini conversations, whether uploaded by you or generated by Gemini, are captured and embedded directly in the Markdown file as base64 data URIs. This creates a fully self-contained export where no external links can break over time.</p>
+    <p>For conversations with many images, this does increase the file size. If you prefer smaller files without embedded images, the extension settings include an option to skip image embedding. In that case, image placeholders are included with descriptions instead.</p>
+
+    <h2>Selective Turn Export</h2>
+    <p>Gemini conversations can be lengthy, especially Deep Research sessions or extended coding projects. The selective turn export lets you pick exactly which message turns to include in the Markdown output.</p>
+    <p>After clicking the export button, choose the conversation turns you want and only those turns are included. This is ideal when you want to extract a specific exchange from a long conversation without exporting hundreds of messages.</p>
+
+    <h2>Filename Templates</h2>
+    <p>Exported Markdown files use intelligent filename templates that include the conversation title and timestamp. The default produces readable filenames like:</p>
+    <ul>
+      <li><code>Gemini-React-Project-2026-03-15.md</code></li>
+      <li><code>Gemini-Data-Analysis-Deep-Research-2026-03-15.md</code></li>
+    </ul>
+    <p>Customize the filename template in the extension settings to match your preferred naming convention. Options include adding prefixes, custom date formats, or conversation IDs.</p>
+
+    <div class="callout callout-success">
+      <p><strong>100% local processing.</strong> Markdown rendering happens entirely within the browser extension. Your conversation data is never transmitted to any external server. The exported .md file is generated in memory and saved directly to your downloads folder.</p>
+    </div>
+
+    <div class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">Does the exporter handle Gemini Deep Research reports?</button>
+        <div class="faq-answer"><p>Yes. Deep Research sessions are recognized through Gemini's immersive panel structure and exported as clean Markdown. The report title, research content, source references, and structure are preserved without leftover UI elements.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Are code blocks preserved in the Markdown export?</button>
+        <div class="faq-answer"><p>Yes. Code blocks are exported as fenced code blocks with their language tags, so syntax highlighting works in any Markdown editor. Inline code is also preserved.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">How are images from Gemini conversations handled?</button>
+        <div class="faq-answer"><p>Images are embedded as base64 data URIs directly within the Markdown file. This makes the export self-contained. You can disable image embedding in settings for smaller file sizes, in which case image placeholders with descriptions are included instead.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I export only part of a Gemini conversation?</button>
+        <div class="faq-answer"><p>Yes. The selective turn export feature lets you choose which message turns to include in the Markdown output. This works for regular chats and Deep Research sessions.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">What happens if Gemini changes its page layout?</button>
+        <div class="faq-answer"><p>The exporter reads Gemini's DOM structure, so major UI redesigns by Google may temporarily affect extraction. The extension is updated regularly to track DOM changes. If exports fail after a Gemini update, check for extension updates or report the issue on GitHub.</p></div>
+      </div>
+    </div>
+
+    <div class="related-pages">
+      <h3>Related Guides</h3>
+      <div class="related-grid">
+        <a href="gemini-exporter.html" class="related-link">Gemini Exporter (All Formats)</a>
+        <a href="markdown-exporter.html" class="related-link">Markdown Export Guide</a>
+        <a href="chatgpt-to-markdown.html" class="related-link">ChatGPT to Markdown</a>
+      </div>
+    </div>
+
+    <h2>How to Export Gemini as Markdown</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-content">
+          <h4>Install AI Chat Exporter</h4>
+          <p>Add the extension from the Chrome Web Store or Firefox Add-ons. No account or API key required.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Open Your Gemini Conversation</h4>
+          <p>Navigate to gemini.google.com and open the conversation you want to export. Works with regular chats and Deep Research outputs.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Select Markdown Format</h4>
+          <p>Click the extension icon and choose Markdown. Configure options for image embedding and filename templates in settings.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Download the .md File</h4>
+          <p>The extension generates and downloads a clean Markdown file. Open it in your preferred editor or move it to your note-taking vault.</p>
+        </div>
+      </div>
+    </div>
+
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -576,6 +576,38 @@
       .footer-link:hover {
         color: var(--text-primary);
       }
+
+      .guide-card {
+        all: unset;
+        cursor: pointer;
+        padding: 14px;
+        border: 1px solid var(--border-color);
+        border-radius: 10px;
+        background: rgba(255, 255, 255, 0.02);
+        display: block;
+        transition: border-color 0.15s ease;
+      }
+
+      .guide-card:hover,
+      .guide-card:focus-visible {
+        border-color: var(--color-primary);
+      }
+
+      .guide-card:focus-visible {
+        outline: 2px solid var(--color-primary);
+        outline-offset: 2px;
+      }
+
+      .guide-card-title {
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 4px;
+      }
+
+      .guide-card-desc {
+        font-size: 0.82rem;
+        color: var(--text-secondary);
+      }
     </style>
   </head>
 
@@ -899,81 +931,81 @@
           Task-specific walkthroughs for exporting AI conversations from each platform and format.
         </p>
         <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 14px">
-          <a href="chatgpt-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">ChatGPT Exporter</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export ChatGPT to Markdown, PDF, JSON &amp; more</div>
+          <a href="chatgpt-exporter.html" class="guide-card">
+            <div class="guide-card-title">ChatGPT Exporter</div>
+            <div class="guide-card-desc">Export ChatGPT to Markdown, PDF, JSON &amp; more</div>
           </a>
-          <a href="chatgpt-to-markdown.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">ChatGPT to Markdown</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Save ChatGPT conversations as .md files</div>
+          <a href="chatgpt-to-markdown.html" class="guide-card">
+            <div class="guide-card-title">ChatGPT to Markdown</div>
+            <div class="guide-card-desc">Save ChatGPT conversations as .md files</div>
           </a>
-          <a href="chatgpt-to-pdf.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">ChatGPT to PDF</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Turn ChatGPT chats into polished PDFs</div>
+          <a href="chatgpt-to-pdf.html" class="guide-card">
+            <div class="guide-card-title">ChatGPT to PDF</div>
+            <div class="guide-card-desc">Turn ChatGPT chats into polished PDFs</div>
           </a>
-          <a href="claude-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Claude Exporter</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export Claude conversations &amp; artifacts</div>
+          <a href="claude-exporter.html" class="guide-card">
+            <div class="guide-card-title">Claude Exporter</div>
+            <div class="guide-card-desc">Export Claude conversations &amp; artifacts</div>
           </a>
-          <a href="claude-to-markdown.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Claude to Markdown</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Claude conversations as clean .md files</div>
+          <a href="claude-to-markdown.html" class="guide-card">
+            <div class="guide-card-title">Claude to Markdown</div>
+            <div class="guide-card-desc">Claude conversations as clean .md files</div>
           </a>
-          <a href="claude-to-obsidian.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Claude to Obsidian</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Sync Claude chats into your Obsidian vault</div>
+          <a href="claude-to-obsidian.html" class="guide-card">
+            <div class="guide-card-title">Claude to Obsidian</div>
+            <div class="guide-card-desc">Sync Claude chats into your Obsidian vault</div>
           </a>
-          <a href="gemini-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Gemini Exporter</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export Google Gemini conversations</div>
+          <a href="gemini-exporter.html" class="guide-card">
+            <div class="guide-card-title">Gemini Exporter</div>
+            <div class="guide-card-desc">Export Google Gemini conversations</div>
           </a>
-          <a href="gemini-to-markdown.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Gemini to Markdown</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Gemini chats as portable Markdown</div>
+          <a href="gemini-to-markdown.html" class="guide-card">
+            <div class="guide-card-title">Gemini to Markdown</div>
+            <div class="guide-card-desc">Gemini chats as portable Markdown</div>
           </a>
-          <a href="deepseek-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">DeepSeek Exporter</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export DeepSeek chats with reasoning blocks</div>
+          <a href="deepseek-exporter.html" class="guide-card">
+            <div class="guide-card-title">DeepSeek Exporter</div>
+            <div class="guide-card-desc">Export DeepSeek chats with reasoning blocks</div>
           </a>
-          <a href="perplexity-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Perplexity Exporter</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export Perplexity searches &amp; answers</div>
+          <a href="perplexity-exporter.html" class="guide-card">
+            <div class="guide-card-title">Perplexity Exporter</div>
+            <div class="guide-card-desc">Export Perplexity searches &amp; answers</div>
           </a>
-          <a href="copilot-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Copilot Exporter</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Save Microsoft Copilot conversations</div>
+          <a href="copilot-exporter.html" class="guide-card">
+            <div class="guide-card-title">Copilot Exporter</div>
+            <div class="guide-card-desc">Save Microsoft Copilot conversations</div>
           </a>
-          <a href="markdown-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Markdown Export Guide</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export any AI chat as Markdown</div>
+          <a href="markdown-exporter.html" class="guide-card">
+            <div class="guide-card-title">Markdown Export Guide</div>
+            <div class="guide-card-desc">Export any AI chat as Markdown</div>
           </a>
-          <a href="pdf-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">PDF Export Guide</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Generate PDFs from AI conversations</div>
+          <a href="pdf-exporter.html" class="guide-card">
+            <div class="guide-card-title">PDF Export Guide</div>
+            <div class="guide-card-desc">Generate PDFs from AI conversations</div>
           </a>
-          <a href="json-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">JSON Export Guide</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Structured JSON with a strict schema</div>
+          <a href="json-exporter.html" class="guide-card">
+            <div class="guide-card-title">JSON Export Guide</div>
+            <div class="guide-card-desc">Structured JSON with a strict schema</div>
           </a>
-          <a href="png-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">PNG Export Guide</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Share AI chats as polished images</div>
+          <a href="png-exporter.html" class="guide-card">
+            <div class="guide-card-title">PNG Export Guide</div>
+            <div class="guide-card-desc">Share AI chats as polished images</div>
           </a>
-          <a href="obsidian-export.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">AI Chat to Obsidian</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Send chats to Obsidian &amp; other PKM apps</div>
+          <a href="obsidian-export.html" class="guide-card">
+            <div class="guide-card-title">AI Chat to Obsidian</div>
+            <div class="guide-card-desc">Send chats to Obsidian &amp; other PKM apps</div>
           </a>
-          <a href="cross-ai-transfer.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Cross-AI Transfer</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Continue chats in another AI platform</div>
+          <a href="cross-ai-transfer.html" class="guide-card">
+            <div class="guide-card-title">Cross-AI Transfer</div>
+            <div class="guide-card-desc">Continue chats in another AI platform</div>
           </a>
-          <a href="ai-chat-backup.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">AI Chat Backup</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Keep safe, searchable archives</div>
+          <a href="ai-chat-backup.html" class="guide-card">
+            <div class="guide-card-title">AI Chat Backup</div>
+            <div class="guide-card-desc">Keep safe, searchable archives</div>
           </a>
-          <a href="latex-export.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
-            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">LaTeX Export</div>
-            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export math-heavy chats for LaTeX</div>
+          <a href="latex-export.html" class="guide-card">
+            <div class="guide-card-title">LaTeX Export</div>
+            <div class="guide-card-desc">Export math-heavy chats for LaTeX</div>
           </a>
         </div>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -890,6 +890,93 @@
           </a>
         </div>
       </div>
+
+      <div style="margin-top: 56px; border-top: 1px solid var(--border-color); padding-top: 40px" id="seo-guides">
+        <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 24px">
+          <h2 style="margin: 0; font-size: 1.4rem; color: var(--text-primary)">Guides &amp; How-To&rsquo;s</h2>
+        </div>
+        <p style="color: var(--text-secondary); margin-bottom: 28px; max-width: 680px">
+          Task-specific walkthroughs for exporting AI conversations from each platform and format.
+        </p>
+        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 14px">
+          <a href="chatgpt-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">ChatGPT Exporter</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export ChatGPT to Markdown, PDF, JSON &amp; more</div>
+          </a>
+          <a href="chatgpt-to-markdown.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">ChatGPT to Markdown</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Save ChatGPT conversations as .md files</div>
+          </a>
+          <a href="chatgpt-to-pdf.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">ChatGPT to PDF</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Turn ChatGPT chats into polished PDFs</div>
+          </a>
+          <a href="claude-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Claude Exporter</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export Claude conversations &amp; artifacts</div>
+          </a>
+          <a href="claude-to-markdown.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Claude to Markdown</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Claude conversations as clean .md files</div>
+          </a>
+          <a href="claude-to-obsidian.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Claude to Obsidian</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Sync Claude chats into your Obsidian vault</div>
+          </a>
+          <a href="gemini-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Gemini Exporter</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export Google Gemini conversations</div>
+          </a>
+          <a href="gemini-to-markdown.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Gemini to Markdown</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Gemini chats as portable Markdown</div>
+          </a>
+          <a href="deepseek-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">DeepSeek Exporter</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export DeepSeek chats with reasoning blocks</div>
+          </a>
+          <a href="perplexity-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Perplexity Exporter</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export Perplexity searches &amp; answers</div>
+          </a>
+          <a href="copilot-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Copilot Exporter</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Save Microsoft Copilot conversations</div>
+          </a>
+          <a href="markdown-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Markdown Export Guide</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export any AI chat as Markdown</div>
+          </a>
+          <a href="pdf-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">PDF Export Guide</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Generate PDFs from AI conversations</div>
+          </a>
+          <a href="json-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">JSON Export Guide</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Structured JSON with a strict schema</div>
+          </a>
+          <a href="png-exporter.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">PNG Export Guide</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Share AI chats as polished images</div>
+          </a>
+          <a href="obsidian-export.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">AI Chat to Obsidian</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Send chats to Obsidian &amp; other PKM apps</div>
+          </a>
+          <a href="cross-ai-transfer.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">Cross-AI Transfer</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Continue chats in another AI platform</div>
+          </a>
+          <a href="ai-chat-backup.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">AI Chat Backup</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Keep safe, searchable archives</div>
+          </a>
+          <a href="latex-export.html" style="all: unset; cursor: pointer; padding: 14px; border: 1px solid var(--border-color); border-radius: 10px; background: rgba(255, 255, 255, 0.02); display: block; transition: border-color 0.15s ease">
+            <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 4px">LaTeX Export</div>
+            <div style="font-size: 0.82rem; color: var(--text-secondary)">Export math-heavy chats for LaTeX</div>
+          </a>
+        </div>
+      </div>
     </main>
 
     <footer>

--- a/docs/json-exporter.html
+++ b/docs/json-exporter.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Chat to JSON — Structured Conversation Export for Developers</title>
+  <meta name="description" content="Export AI conversations as structured JSON with normalized schema. Perfect for developers, backups, and AI workflows. Free, open-source." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/json-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/json-exporter.html" />
+  <meta property="og:title" content="AI Chat to JSON — Structured Conversation Export for Developers" />
+  <meta property="og:description" content="Export AI conversations as structured JSON with normalized schema. Perfect for developers, backups, and AI workflows. Free, open-source." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>›</span> JSON Export</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Developer Friendly</span>
+      <h1>AI Chat to JSON — Structured Data Export</h1>
+      <p class="hero-subtitle">Export AI conversations as structured JSON with a normalized schema. Machine-readable output for developers, researchers, and automation workflows.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <section class="features-grid">
+      <div class="feature-card">
+        <h3>Normalized Schema</h3>
+        <p>Every export follows a consistent JSON Schema v1 structure regardless of which AI platform produced the conversation. Parse it once, process conversations from any source.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Full Metadata</h3>
+        <p>Model name, platform, conversation ID, timestamp, and message roles are all preserved in structured fields. Build analytics dashboards or filter conversations programmatically.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Role Classification</h3>
+        <p>Every message is tagged with its role: user, assistant, system, tool, artifact, or unknown. This makes it straightforward to separate inputs from outputs in downstream processing.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Machine-Readable</h3>
+        <p>Valid JSON that parses with no errors in any language. Import directly into databases, dataframes, search indexes, or custom pipelines without cleanup or transformation.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Backup and Restore</h3>
+        <p>JSON is the ideal format for programmatic backup and restore. Re-import your conversation archive into tools that accept JSON, or build your own backup system on top of the export files.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Platform Agnostic</h3>
+        <p>Whether the conversation came from ChatGPT, Claude, Gemini, or DeepSeek, the output structure is identical. Your code does not need platform-specific parsers.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>JSON Schema v1 Structure</h2>
+      <p>Every JSON export from AI Chat Exporter follows the v1 schema definition. The structure is designed to be both human-inspectable and machine-processable. Here is an overview of the top-level fields:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>schema_version</code></td><td>string</td><td>Schema version identifier (currently "v1")</td></tr>
+            <tr><td><code>source</code></td><td>object</td><td>Source metadata: platform name, URL, and extension version</td></tr>
+            <tr><td><code>metadata</code></td><td>object</td><td>Conversation metadata: title, model, timestamp, conversation ID</td></tr>
+            <tr><td><code>messages</code></td><td>array</td><td>Ordered array of message objects</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>Each message object in the <code>messages</code> array contains:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>role</code></td><td>string</td><td>One of: user, assistant, system, tool, artifact, unknown</td></tr>
+            <tr><td><code>content</code></td><td>string</td><td>The message text content in Markdown format</td></tr>
+            <tr><td><code>timestamp</code></td><td>string (ISO 8601)</td><td>When the message was sent, if available</td></tr>
+            <tr><td><code>thinking</code></td><td>string or null</td><td>Extended thinking / chain-of-thought content, if present</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The full schema definition is available in the repository at <code>schemas/export-v1.schema.json</code>. You can use it with JSON Schema validators to enforce structure in your own pipelines.</p>
+    </section>
+
+    <section>
+      <h2>What the Raw JSON Looks Like</h2>
+      <p>Here is a simplified example of a JSON export with two messages:</p>
+      <div class="callout callout-info">
+        <pre>{
+  "schema_version": "v1",
+  "source": {
+    "platform": "chatgpt",
+    "url": "https://chatgpt.com/c/abc123",
+    "extension_version": "1.0.0"
+  },
+  "metadata": {
+    "title": "Python recursion explanation",
+    "model": "gpt-4o",
+    "conversation_id": "abc123",
+    "exported_at": "2026-09-09T10:30:00Z"
+  },
+  "messages": [
+    {
+      "role": "user",
+      "content": "Explain recursion in Python",
+      "timestamp": "2026-09-09T10:29:00Z",
+      "thinking": null
+    },
+    {
+      "role": "assistant",
+      "content": "Recursion occurs when a function calls itself...",
+      "timestamp": "2026-09-09T10:29:30Z",
+      "thinking": null
+    }
+  ]
+}</pre>
+      </div>
+      <p>This structure is consistent whether the conversation came from ChatGPT, Claude, Gemini, or any other supported platform. The <code>source.platform</code> field tells you where it came from, and the <code>messages</code> array is always a flat, ordered list.</p>
+    </section>
+
+    <section>
+      <h2>Use Cases for JSON Export</h2>
+      <p><strong>Programmatic Processing</strong> — Load the JSON into Python, JavaScript, Go, or any language with native JSON support. Filter messages by role, extract code blocks, build summaries, or perform analytics on conversation patterns.</p>
+      <div class="callout callout-info">
+        <pre>import json
+
+with open("conversation.json") as f:
+    data = json.load(f)
+
+for msg in data["messages"]:
+    if msg["role"] == "assistant":
+        print(msg["content"][:200])</pre>
+      </div>
+      <p><strong>Backup and Restore</strong> — Build an automated backup pipeline that exports your AI conversations daily. The normalized schema means a single restore script works for conversations from every platform.</p>
+      <p><strong>Training Data Preparation</strong> — Researchers and ML engineers can use JSON exports as structured input for fine-tuning datasets. The role field cleanly separates prompts from completions without regex or heuristics.</p>
+      <p><strong>Analytics and Dashboards</strong> — Import JSON exports into databases like PostgreSQL (via JSONB), Elasticsearch, or MongoDB. Build dashboards showing conversation volume, platform usage, model distribution, and response patterns.</p>
+      <p><strong>Migration Between Platforms</strong> — Moving from ChatGPT to Claude or vice versa? Export your conversations as JSON and write a simple script to reconstruct them in the target platform's format, or simply archive them for reference.</p>
+      <p><strong>Custom Tooling</strong> — Build your own chat interface, search engine, or knowledge base on top of exported JSON data. The structured format makes indexing, full-text search, and retrieval straightforward.</p>
+    </section>
+
+    <section>
+      <h2>JSON Export vs. ChatGPT's Official Export</h2>
+      <p>OpenAI offers a data export feature in ChatGPT settings, but the output is a ZIP file containing unstructured conversation dumps in a custom format that changes between versions. Here is how AI Chat Exporter's JSON export compares:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr><th>Feature</th><th>ChatGPT Official Export</th><th>AI Chat Exporter JSON</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Format</td><td>Proprietary, undocumented</td><td>JSON Schema v1, documented</td></tr>
+            <tr><td>Platform coverage</td><td>ChatGPT only</td><td>17 platforms</td></tr>
+            <tr><td>Role labels</td><td>Inconsistent</td><td>Normalized (user, assistant, tool, etc.)</td></tr>
+            <tr><td>Model metadata</td><td>Not always present</td><td>Captured when available</td></tr>
+            <tr><td>Thinking traces</td><td>Not included</td><td>Preserved in thinking field</td></tr>
+            <tr><td>Export trigger</td><td>Full account export (all conversations)</td><td>Per-conversation, on demand</td></tr>
+            <tr><td>Availability</td><td>Request and wait for email</td><td>Instant download</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>Supported Platforms</h2>
+      <p>JSON export is available for all 17 platforms: ChatGPT, Claude, Gemini, DeepSeek, Perplexity, Copilot, Qwen, Mistral, Meta AI, NotebookLM, Google AI Studio, Google Cloud Assist, Google Search AI, Z.AI, Proton Lumo, Joyland, and Chub. The output schema is identical across all platforms.</p>
+    </section>
+
+    <section class="steps">
+      <h2>How to Export AI Chats to JSON</h2>
+      <div class="step">
+        <h3>1. Install the Extension</h3>
+        <p>Add AI Chat Exporter from the Chrome Web Store or Firefox Add-ons. Free, no account required, no configuration needed.</p>
+      </div>
+      <div class="step">
+        <h3>2. Open Any Supported AI Chat</h3>
+        <p>Navigate to a conversation on any of the 18 supported platforms. The extension detects the active chat and parses the DOM.</p>
+      </div>
+      <div class="step">
+        <h3>3. Click Export and Select JSON</h3>
+        <p>Click the toolbar icon and choose JSON. The file downloads immediately as a <code>.json</code> file named after the conversation title.</p>
+      </div>
+    </section>
+
+    <section class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">What does the JSON look like?</button>
+        <div class="faq-answer"><p>The JSON has a top-level structure with schema_version, source, metadata, and messages fields. Each message has a role (user, assistant, system, tool, artifact, or unknown) and content in Markdown. The full schema definition is available at schemas/export-v1.schema.json in the GitHub repository.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I import into databases?</button>
+        <div class="faq-answer"><p>Yes. The JSON is valid and well-structured for direct import into PostgreSQL (JSONB columns), MongoDB documents, Elasticsearch indices, or any data store that accepts JSON. The consistent schema means you can write a single import script that works for all platforms.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">What metadata is included?</button>
+        <div class="faq-answer"><p>Each export includes the source platform, the source URL, the extension version, the conversation title, the AI model name (when available), the conversation ID, the export timestamp, and the timestamp of each individual message. This metadata enables filtering, sorting, and analytics.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Is there a schema definition?</button>
+        <div class="faq-answer"><p>Yes. The JSON Schema v1 definition is published in the GitHub repository at schemas/export-v1.schema.json. You can use this file with JSON Schema validators in any language to enforce structure and catch anomalies in your data pipeline.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">How do I parse it in Python?</button>
+        <div class="faq-answer"><p>Use Python's built-in json module: <code>import json; data = json.load(open("export.json"))</code>. The data["messages"] array contains all messages, each with a role and content field. You can filter by role, iterate over messages, or load the entire structure into a pandas DataFrame for analysis.</p></div>
+      </div>
+    </section>
+
+    <section class="related-pages">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="markdown-exporter.html" class="related-link">
+          <h3>Markdown Export</h3>
+          <p>Export conversations to portable Markdown files for note-taking workflows.</p>
+        </a>
+        <a href="ai-chat-backup.html" class="related-link">
+          <h3>AI Chat Backup</h3>
+          <p>Build automated backup pipelines for your AI conversation archives.</p>
+        </a>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/json-exporter.html
+++ b/docs/json-exporter.html
@@ -202,7 +202,7 @@ for msg in data["messages"]:
       </div>
       <div class="step">
         <h3>2. Open Any Supported AI Chat</h3>
-        <p>Navigate to a conversation on any of the 18 supported platforms. The extension detects the active chat and parses the DOM.</p>
+        <p>Navigate to a conversation on any of the 17 supported platforms. The extension detects the active chat and parses the DOM.</p>
       </div>
       <div class="step">
         <h3>3. Click Export and Select JSON</h3>
@@ -257,8 +257,22 @@ for msg in data["messages"]:
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/latex-export.html
+++ b/docs/latex-export.html
@@ -1,0 +1,392 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Export LaTeX Math from AI Conversations — Math-Ready Markdown &amp; PDF</title>
+  <meta name="description" content="Export AI conversations with properly formatted LaTeX math equations. Supports $$ block and $ inline math. KaTeX rendering. Free extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/latex-export.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/latex-export.html" />
+  <meta property="og:title" content="Export LaTeX Math from AI Conversations — Math-Ready Markdown &amp; PDF" />
+  <meta property="og:description" content="Export AI conversations with properly formatted LaTeX math equations. Supports $$ block and $ inline math. KaTeX rendering. Free extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>&rsaquo;</span> <span>LaTeX Export</span></div>
+
+  <main>
+    <div class="hero">
+      <span class="badge">KaTeX Powered</span>
+      <h1>Export LaTeX Math &mdash; Preserved Equations from Any AI</h1>
+      <p class="hero-subtitle">Export AI conversations with properly formatted LaTeX math equations. Block and inline math preserved with correct delimiters. Renders in Obsidian, HTML, and PDF.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <section class="content-section">
+      <h2>The Problem: Broken Math in Exported Conversations</h2>
+      <p>If you have ever exported a conversation containing math equations from an AI platform using a generic tool or manual copy-paste, you have seen the result: backslashes stripped, dollar signs mangled, inline math merged into the surrounding text, and block equations rendered as unreadable garbled text.</p>
+      <p>This happens because most export tools treat AI output as plain text. They do not distinguish between a dollar sign used as currency and a dollar sign used as a LaTeX delimiter. They strip backslashes as escape characters rather than recognizing them as part of LaTeX commands. The result is that a beautifully formatted equation like:</p>
+      <p><code>$$\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}$$</code></p>
+      <p>becomes a broken mess in the exported file.</p>
+      <p>AI Chat Exporter handles LaTeX math as a first-class feature. The extension identifies math delimiters in the AI's response, protects them through the export pipeline, and outputs them with correct formatting in every export format.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>How AI Chat Exporter Handles LaTeX</h2>
+      <div class="features-grid">
+        <div class="feature-card">
+          <h3>Delimiter Normalization</h3>
+          <p>AI platforms use different math delimiter conventions. ChatGPT and Claude typically use <code>$$...$$</code> for block math and <code>$...$</code> for inline math. Some responses use <code>\[...\]</code> and <code>\(...\)</code> instead. The extension normalizes all variants to the standard <code>$$...$$</code> and <code>$...$</code> delimiters that most renderers expect.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Backslash Protection</h3>
+          <p>LaTeX commands begin with backslashes: <code>\frac</code>, <code>\sum</code>, <code>\int</code>, <code>\alpha</code>. During Markdown conversion, naive processors strip these as escape characters. AI Chat Exporter identifies LaTeX content blocks and protects all backslash sequences, ensuring every command survives the export pipeline intact.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Bracket Syntax Preservation</h3>
+          <p>The <code>\[...\]</code> and <code>\(...\)</code> bracket syntaxes are preserved when used. The extension detects these patterns and maintains them alongside the <code>$$</code> and <code>$</code> delimiters, giving you flexibility in how your math renders in the target application.</p>
+        </div>
+        <div class="feature-card">
+          <h3>HTML KaTeX Auto-Render</h3>
+          <p>When exporting to HTML, the extension includes KaTeX JavaScript and CSS. Math equations in the HTML output are auto-rendered when you open the file in a browser. Block math displays centered, inline math flows with the text, and the full KaTeX symbol set is available.</p>
+        </div>
+        <div class="feature-card">
+          <h3>PrismJS LaTeX Highlighting</h3>
+          <p>When math appears inside fenced code blocks (for example, when showing raw LaTeX source), PrismJS syntax highlighting applies. Keywords, commands, braces, and delimiters are color-coded for readability in code blocks and HTML exports.</p>
+        </div>
+        <div class="feature-card">
+          <h3>PNG KaTeX Rendering</h3>
+          <p>When exporting as PNG, equations are rendered through KaTeX before the final image is captured. The result is a pixel-perfect image of your equations with proper typography, spacing, and formatting. Share equations on social media or in documents without worrying about renderer compatibility.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Supported Math Syntax</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Syntax</th>
+              <th>Type</th>
+              <th>Example</th>
+              <th>Handling</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>$$...$$</code></td>
+              <td>Block math</td>
+              <td><code>$$\sum_{i=1}^{n} x_i$$</code></td>
+              <td>Preserved as-is, rendered in HTML/PNG exports</td>
+            </tr>
+            <tr>
+              <td><code>$...$</code></td>
+              <td>Inline math</td>
+              <td>The equation <code>$E = mc^2$</code> is famous</td>
+              <td>Preserved, rendered inline in HTML and PNG</td>
+            </tr>
+            <tr>
+              <td><code>\[...\]</code></td>
+              <td>Block math (alternate)</td>
+              <td><code>\[\frac{a}{b}\]</code></td>
+              <td>Normalized to <code>$$...$$</code> or preserved</td>
+            </tr>
+            <tr>
+              <td><code>\(...\)</code></td>
+              <td>Inline math (alternate)</td>
+              <td><code>\(x^2\)</code></td>
+              <td>Normalized to <code>$...$</code> or preserved</td>
+            </tr>
+            <tr>
+              <td><code>```latex</code></td>
+              <td>Code block</td>
+              <td>Raw LaTeX source in fenced block</td>
+              <td>Preserved with PrismJS syntax highlighting</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Supported Platforms for Math</h2>
+      <p>Not all AI platforms render math the same way. AI Chat Exporter handles math extraction from platforms where equations are commonly used:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Platform</th>
+              <th>Math Rendering</th>
+              <th>Common Use Cases</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>ChatGPT (GPT-4)</strong></td>
+              <td>Uses <code>$$</code> and <code>$</code> delimiters natively</td>
+              <td>Calculus, linear algebra, statistics, physics</td>
+            </tr>
+            <tr>
+              <td><strong>Claude</strong></td>
+              <td>Uses <code>$$</code> and <code>$</code> delimiters</td>
+              <td>Mathematical proofs, formal logic, probability</td>
+            </tr>
+            <tr>
+              <td><strong>Gemini</strong></td>
+              <td>Renders math in response UI, exports with delimiters</td>
+              <td>STEM coursework, research derivations</td>
+            </tr>
+            <tr>
+              <td><strong>DeepSeek</strong></td>
+              <td>Uses LaTeX delimiters, especially for DeepThink</td>
+              <td>Mathematical reasoning, proof verification</td>
+            </tr>
+            <tr>
+              <td><strong>Other Platforms</strong></td>
+              <td>Varies; extension normalizes what it finds</td>
+              <td>Any math content in supported platforms</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Output Formats with Math Support</h2>
+      <div class="steps">
+        <div class="step">
+          <div class="step-number">1</div>
+          <div class="step-content">
+            <h3>Markdown (.md)</h3>
+            <p>Equations are exported with <code>$$</code> and <code>$</code> delimiters. This format is KaTeX-ready and works directly with Obsidian (with MathJax or KaTeX plugin), Logseq, Typora, HackMD, and any editor that supports KaTeX or MathJax rendering.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">2</div>
+          <div class="step-content">
+            <h3>HTML (.html)</h3>
+            <p>The HTML export bundles KaTeX JavaScript and CSS. Open the file in any modern browser and equations render automatically. Block math is centered, inline math flows with the text, and the full KaTeX symbol library is available. No additional setup required.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">3</div>
+          <div class="step-content">
+            <h3>PDF (.pdf)</h3>
+            <p>Equations are rendered through KaTeX before PDF generation. The result is a print-ready document with properly typeset mathematics. Supports multi-page documents with page breaks, table of contents, and both dark and light themes.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">4</div>
+          <div class="step-content">
+            <h3>PNG (.png)</h3>
+            <p>Full conversation is rendered to a scrollable image with KaTeX-rendered equations. Equations appear with professional typography and correct spacing. Ideal for sharing math-heavy conversations on social media or in presentations.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Use Cases</h2>
+      <div class="features-grid">
+        <div class="feature-card">
+          <h3>Academic Notes</h3>
+          <p>Export conversations where you worked through mathematical problems. The preserved equations become study notes you can reference during exams or research. Import into Obsidian and link to your course notes.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Research Documentation</h3>
+          <p>Keep a record of AI-assisted derivations, proofs, and calculations. The structured JSON export preserves equation metadata alongside the conversation context for future reference.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Paper Drafting</h3>
+          <p>Export math-heavy brainstorming sessions and import the LaTeX content directly into your paper. The extension preserves LaTeX syntax so you can copy equations from the exported file into your LaTeX document without reformatting.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Teaching Materials</h3>
+          <p>Create PDF handouts from conversations about mathematical topics. The rendered equations in the PDF export look professional and are ready to distribute to students or colleagues.</p>
+        </div>
+        <div class="feature-card">
+          <h3>LaTeX Snippet Library</h3>
+          <p>Build a searchable library of LaTeX code snippets by exporting conversations that contain formatted equations. The PrismJS-highlighted code blocks in Markdown and HTML exports make it easy to find and reuse specific LaTeX constructions.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Cross-Platform Math Transfer</h3>
+          <p>Export a math conversation from ChatGPT and continue it on Claude using cross-AI transfer. Equations are preserved in the transfer, so the target AI receives the full mathematical context.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Using Exported Math in Obsidian</h2>
+      <p>Obsidian supports math rendering through its built-in MathJax engine and through community plugins like KaTeX. When you export a conversation with equations using AI Chat Exporter's Markdown format, the resulting file works directly in Obsidian:</p>
+      <ul>
+        <li>Block equations (<code>$$...$$</code>) render as centered, display-style math.</li>
+        <li>Inline equations (<code>$...$</code>) render within the text flow.</li>
+        <li>No plugin configuration is required for basic math rendering.</li>
+        <li>Equations are searchable as text when you search your vault.</li>
+        <li>You can link to exported math notes from other notes and build a connected knowledge base of mathematical content.</li>
+      </ul>
+      <div class="callout callout-info">
+        <strong>Obsidian tip:</strong> Combine the Obsidian export feature with LaTeX export to send math-heavy conversations directly to your vault. Configure your vault name in the extension options, click the Obsidian transfer button, and equations are ready to render.
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Comparison with Other Export Approaches</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Approach</th>
+              <th>Math Handling</th>
+              <th>Result</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Manual copy-paste</td>
+              <td>Strips delimiters, backslashes become escape characters</td>
+              <td>Equations broken, unreadable</td>
+            </tr>
+            <tr>
+              <td>Generic web clipper</td>
+              <td>Captures rendered HTML, loses LaTeX source</td>
+              <td>Visual only, not editable as LaTeX</td>
+            </tr>
+            <tr>
+              <td>ChatGPT data export</td>
+              <td>Includes raw LaTeX in JSON but no formatting</td>
+              <td>Usable but requires parsing</td>
+            </tr>
+            <tr>
+              <td><strong>AI Chat Exporter</strong></td>
+              <td>Normalizes delimiters, protects backslashes, renders in HTML/PNG</td>
+              <td>Clean, portable, render-ready math in every format</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq">
+        <div class="faq-item">
+          <button class="faq-question">Will equations render in Obsidian?</button>
+          <div class="faq-answer">
+            <p>Yes. Obsidian has built-in MathJax support. Block equations enclosed in <code>$$...$$</code> render as display math, and inline equations enclosed in <code>$...$</code> render within the text. No additional plugins are required for basic math rendering. For advanced KaTeX features, the Obsidian community offers KaTeX and MathJax plugins.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Does it handle both inline and block math?</button>
+          <div class="faq-answer">
+            <p>Yes. The extension recognizes and preserves both inline math (single dollar signs: <code>$equation$</code>) and block math (double dollar signs: <code>$$equation$$</code>). It also handles the alternate bracket syntaxes (<code>\[...\]</code> and <code>\(...\)</code>) and normalizes them to the standard delimiter format.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">What about specialized packages like Chemfig or TikZ?</button>
+          <div class="faq-answer">
+            <p>The extension preserves the LaTeX source code for any equation, including those that use specialized packages. However, rendering depends on the target application. KaTeX (used in HTML and PNG exports) supports a subset of LaTeX math commands. Full LaTeX packages like Chemfig, TikZ, and PSTricks require a full LaTeX compiler and cannot be rendered by KaTeX. The raw LaTeX source is preserved in Markdown and JSON exports for use with a full LaTeX toolchain.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Can I get a rendered PNG of math equations?</button>
+          <div class="faq-answer">
+            <p>Yes. The PNG export renders equations through KaTeX before capturing the final image. Block equations appear centered with professional typography. Inline equations render within the text. The resulting image can be shared directly in documents, presentations, or on social media.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">How do I use exported LaTeX in a paper?</button>
+          <div class="faq-answer">
+            <p>Export the conversation as Markdown. The LaTeX equations in the file use standard <code>$$</code> and <code>$</code> delimiters that are directly compatible with LaTeX document classes. Copy the equation blocks from the exported file into your .tex document. If your paper uses <code>\[...\]</code> delimiters, a simple find-and-replace from <code>$$</code> to <code>\[</code> and <code>\]</code> converts the format.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Does math export work with all platforms?</button>
+          <div class="faq-answer">
+            <p>Math preservation works on any platform where the AI outputs LaTeX equations. ChatGPT, Claude, Gemini, and DeepSeek consistently use LaTeX delimiters. Other platforms may or may not include math notation. The extension preserves whatever math syntax it finds in the conversation, normalizing delimiters where possible.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="markdown-exporter.html" class="related-link">
+          <h3>Markdown Exporter</h3>
+          <p>Full guide to Markdown export with code highlighting, formatting, and math preservation.</p>
+        </a>
+        <a href="obsidian-export.html" class="related-link">
+          <h3>Obsidian Export</h3>
+          <p>Send math-heavy conversations directly to your Obsidian vault with one click.</p>
+        </a>
+        <a href="chatgpt-exporter.html" class="related-link">
+          <h3>ChatGPT Exporter</h3>
+          <p>Export ChatGPT conversations with preserved math, code, and formatting.</p>
+        </a>
+        <a href="ai-chat-backup.html" class="related-link">
+          <h3>AI Chat Backup</h3>
+          <p>Archive your math and research conversations for permanent reference.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <div class="callout callout-success">
+        <strong>Stop losing your math to broken exports.</strong> Install AI Chat Exporter and preserve every equation, every derivation, every formula. KaTeX-powered rendering in Markdown, HTML, PDF, and PNG.
+        <div class="cta-group">
+          <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+          <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/latex-export.html
+++ b/docs/latex-export.html
@@ -188,28 +188,24 @@
       <h2>Output Formats with Math Support</h2>
       <div class="steps">
         <div class="step">
-          <div class="step-number">1</div>
           <div class="step-content">
             <h3>Markdown (.md)</h3>
             <p>Equations are exported with <code>$$</code> and <code>$</code> delimiters. This format is KaTeX-ready and works directly with Obsidian (with MathJax or KaTeX plugin), Logseq, Typora, HackMD, and any editor that supports KaTeX or MathJax rendering.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">2</div>
           <div class="step-content">
             <h3>HTML (.html)</h3>
             <p>The HTML export bundles KaTeX JavaScript and CSS. Open the file in any modern browser and equations render automatically. Block math is centered, inline math flows with the text, and the full KaTeX symbol library is available. No additional setup required.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">3</div>
           <div class="step-content">
             <h3>PDF (.pdf)</h3>
             <p>Equations are rendered through KaTeX before PDF generation. The result is a print-ready document with properly typeset mathematics. Supports multi-page documents with page breaks, table of contents, and both dark and light themes.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">4</div>
           <div class="step-content">
             <h3>PNG (.png)</h3>
             <p>Full conversation is rendered to a scrollable image with KaTeX-rendered equations. Equations appear with professional typography and correct spacing. Ideal for sharing math-heavy conversations on social media or in presentations.</p>
@@ -384,8 +380,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/markdown-exporter.html
+++ b/docs/markdown-exporter.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>AI Chat to Markdown — Export Any AI Conversation as Markdown</title>
-  <meta name="description" content="Export conversations from ChatGPT, Claude, Gemini, DeepSeek and 15+ AI platforms to clean Markdown. Preserves code, math, tables. Free." />
+  <meta name="description" content="Export conversations from ChatGPT, Claude, Gemini, DeepSeek and 13 other AI platforms to clean Markdown. Preserves code, math, tables. Free." />
   <link rel="canonical" href="https://ai-chat-exporter.covai.org/markdown-exporter.html" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://ai-chat-exporter.covai.org/markdown-exporter.html" />
   <meta property="og:title" content="AI Chat to Markdown — Export Any AI Conversation as Markdown" />
-  <meta property="og:description" content="Export conversations from ChatGPT, Claude, Gemini, DeepSeek and 15+ AI platforms to clean Markdown. Preserves code, math, tables. Free." />
+  <meta property="og:description" content="Export conversations from ChatGPT, Claude, Gemini, DeepSeek and 13 other AI platforms to clean Markdown. Preserves code, math, tables. Free." />
   <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
   <meta property="og:site_name" content="AI Chat Exporter" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/docs/markdown-exporter.html
+++ b/docs/markdown-exporter.html
@@ -167,7 +167,7 @@
             <tr><td>Image URLs</td><td>Lost</td><td>Markdown image syntax</td></tr>
             <tr><td>Nested lists</td><td>Collapsed</td><td>Proper indentation</td></tr>
             <tr><td>Thinking traces</td><td>Lost</td><td>Captured in details blocks</td></tr>
-            <tr><td>Metadata (model, date)</td><td>Lost</td><td>Written to frontmatter</td></tr>
+            <tr><td>Metadata (model, date)</td><td>Lost</td><td>Emitted as Source, Date, and Model fields</td></tr>
           </tbody>
         </table>
       </div>
@@ -181,7 +181,7 @@
       </div>
       <div class="step">
         <h3>2. Open Any Supported AI Chat</h3>
-        <p>Navigate to ChatGPT, Claude, Gemini, or any of the 18 supported platforms and have a conversation as you normally would.</p>
+        <p>Navigate to ChatGPT, Claude, Gemini, or any of the 17 supported platforms and have a conversation as you normally would.</p>
       </div>
       <div class="step">
         <h3>3. Click the Export Button</h3>
@@ -244,8 +244,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/markdown-exporter.html
+++ b/docs/markdown-exporter.html
@@ -1,0 +1,252 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Chat to Markdown — Export Any AI Conversation as Markdown</title>
+  <meta name="description" content="Export conversations from ChatGPT, Claude, Gemini, DeepSeek and 15+ AI platforms to clean Markdown. Preserves code, math, tables. Free." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/markdown-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/markdown-exporter.html" />
+  <meta property="og:title" content="AI Chat to Markdown — Export Any AI Conversation as Markdown" />
+  <meta property="og:description" content="Export conversations from ChatGPT, Claude, Gemini, DeepSeek and 15+ AI platforms to clean Markdown. Preserves code, math, tables. Free." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>›</span> Markdown Export</div>
+  <main>
+    <div class="hero">
+      <span class="badge">All Platforms</span>
+      <h1>AI Chat to Markdown — Universal Markdown Export</h1>
+      <p class="hero-subtitle">Export conversations from any AI platform to clean, portable Markdown files in one click. Code blocks, math, tables, and thinking traces all preserved.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <section class="features-grid">
+      <div class="feature-card">
+        <h3>Code Blocks Preserved</h3>
+        <p>Fenced code blocks with language tags stay intact. Syntax-highlighted snippets copy exactly as they appeared in the AI response, ready for pasting into your editor.</p>
+      </div>
+      <div class="feature-card">
+        <h3>LaTeX Math Rendering</h3>
+        <p>Both inline ($...$) and display ($$...$$) LaTeX notation are exported verbatim. Paste into Obsidian, Typora, or any MathJax-compatible renderer and the math just works.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Tables and Lists</h3>
+        <p>Markdown tables, ordered lists, unordered lists, and nested structures all come through with their original formatting. No more re-creating tables by hand.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Thinking Blocks</h3>
+        <p>Claude extended thinking, DeepSeek reasoning traces, and other chain-of-thought blocks are captured inside collapsible details elements so you can review the AI's process.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Images and Links</h3>
+        <p>Image URLs and hyperlinks are preserved as Markdown image and link syntax. External references remain clickable and inline images render wherever Markdown is supported.</p>
+      </div>
+      <div class="feature-card">
+        <h3>100% Local</h3>
+        <p>Export runs entirely in your browser. Nothing is sent to any server. Your conversations never leave your machine — the extension parses the DOM and generates the file locally.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>Why Markdown Is the Universal Format for AI Chat Exports</h2>
+      <p>When you select and copy text from an AI chat interface, you lose all structure. Code blocks become plain text, tables collapse into spaces, math vanishes, and images disappear. Markdown solves this because it is both human-readable and machine-parseable.</p>
+      <p>Markdown is supported natively by thousands of tools — note-taking apps, documentation generators, static site hosts, wikis, and databases. A Markdown file from AI Chat Exporter works today in Obsidian, Notion, Logseq, Bear, Joplin, GitBook, Docusaurus, Hugo, Jekyll, and virtually any text editor.</p>
+      <p>Because the format is plain text, your exports are future-proof. They will open in any editor fifty years from now without proprietary software. This is the single biggest advantage over PDF or Word exports, which require specific applications to view and edit.</p>
+    </section>
+
+    <section>
+      <h2>What Gets Preserved in a Markdown Export</h2>
+      <p>The extension does a deep traversal of the AI chat DOM and reconstructs the conversation structure in Markdown. Here is what comes through:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr><th>Element</th><th>How It Is Exported</th><th>Example</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Code blocks</td><td>Fenced with triple backticks and language tag</td><td><code>```python ... ```</code></td></tr>
+            <tr><td>Inline code</td><td>Single backtick wrapping</td><td><code>`variable`</code></td></tr>
+            <tr><td>LaTeX (display)</td><td>Double dollar signs</td><td><code>$$E = mc^2$$</code></td></tr>
+            <tr><td>LaTeX (inline)</td><td>Single dollar signs</td><td><code>$x^2$</code></td></tr>
+            <tr><td>Tables</td><td>Standard Markdown pipe tables</td><td><code>| Col | Col |</code></td></tr>
+            <tr><td>Ordered lists</td><td>Numbered Markdown lists</td><td><code>1. First</code></td></tr>
+            <tr><td>Unordered lists</td><td>Bullet-point Markdown lists</td><td><code>- Item</code></td></tr>
+            <tr><td>Links</td><td>Inline Markdown links</td><td><code>[text](url)</code></td></tr>
+            <tr><td>Images</td><td>Markdown image syntax</td><td><code>![alt](url)</code></td></tr>
+            <tr><td>Thinking traces</td><td>Collapse block with details/summary</td><td><code>&lt;details&gt;</code></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>Supported Platforms</h2>
+      <p>AI Chat Exporter works with 17 AI platforms and counting. Every platform produces clean Markdown output from the same one-click workflow.</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr><th>Platform</th><th>Markdown Support</th><th>Thinking Traces</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>ChatGPT</td><td>Full</td><td>Yes</td></tr>
+            <tr><td>Claude</td><td>Full</td><td>Yes</td></tr>
+            <tr><td>Gemini</td><td>Full</td><td>Yes</td></tr>
+            <tr><td>DeepSeek</td><td>Full</td><td>Yes</td></tr>
+            <tr><td>Perplexity</td><td>Full</td><td>No</td></tr>
+            <tr><td>Copilot</td><td>Full</td><td>No</td></tr>
+            <tr><td>Qwen</td><td>Full</td><td>No</td></tr>
+            <tr><td>Mistral</td><td>Full</td><td>No</td></tr>
+            <tr><td>Meta AI</td><td>Full</td><td>No</td></tr>
+            <tr><td>NotebookLM</td><td>Full</td><td>No</td></tr>
+            <tr><td>Google AI Studio</td><td>Full</td><td>No</td></tr>
+            <tr><td>Google Cloud Assist</td><td>Full</td><td>No</td></tr>
+            <tr><td>Google Search AI</td><td>Full</td><td>No</td></tr>
+            <tr><td>Z.AI</td><td>Full</td><td>No</td></tr>
+            <tr><td>Proton Lumo</td><td>Full</td><td>No</td></tr>
+            <tr><td>Joyland</td><td>Full</td><td>No</td></tr>
+            <tr><td>Chub</td><td>Full</td><td>No</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>Real-World Use Cases</h2>
+      <p>Markdown export is the most versatile output format because it plugs into almost every knowledge-management and documentation workflow.</p>
+      <p><strong>Obsidian and Personal Knowledge Management</strong> — Drop exported files into your Obsidian vault and they are immediately searchable, linkable, and part of your graph. Use wikilinks to connect conversations to your other notes.</p>
+      <p><strong>Notion Import</strong> — Notion accepts Markdown natively via paste or file import. Each export becomes a full page in your workspace with code blocks, headings, and tables intact.</p>
+      <p><strong>GitHub Gists and Repos</strong> — Share code snippets from AI conversations by pasting the Markdown directly into a gist or repository README. Code fences render automatically on GitHub.</p>
+      <p><strong>Documentation</strong> — Teams using Docusaurus, MkDocs, Hugo, or Jekyll can drop AI conversation exports into their docs site. The Markdown renders with syntax highlighting and math support out of the box.</p>
+      <p><strong>Research Notes</strong> — Academics and researchers archive AI-assisted brainstorming sessions as Markdown files, preserving the mathematical notation and structured reasoning for later review.</p>
+    </section>
+
+    <section>
+      <h2>Markdown vs. Plain Text Copy</h2>
+      <p>When you select all text in a ChatGPT response and paste it elsewhere, here is what you lose:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr><th>What You Lose</th><th>Plain Text Copy</th><th>AI Chat Exporter Markdown</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Code language tags</td><td>Lost</td><td>Preserved</td></tr>
+            <tr><td>Table structure</td><td>Collapsed to spaces</td><td>Full pipe-table syntax</td></tr>
+            <tr><td>Math notation</td><td>Rendered as images or lost</td><td>Raw LaTeX preserved</td></tr>
+            <tr><td>Heading hierarchy</td><td>Flattened</td><td>H1 through H6</td></tr>
+            <tr><td>Image URLs</td><td>Lost</td><td>Markdown image syntax</td></tr>
+            <tr><td>Nested lists</td><td>Collapsed</td><td>Proper indentation</td></tr>
+            <tr><td>Thinking traces</td><td>Lost</td><td>Captured in details blocks</td></tr>
+            <tr><td>Metadata (model, date)</td><td>Lost</td><td>Written to frontmatter</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="steps">
+      <h2>How to Export AI Chats to Markdown</h2>
+      <div class="step">
+        <h3>1. Install the Extension</h3>
+        <p>Add AI Chat Exporter from the Chrome Web Store or Firefox Add-ons. The extension is free, open-source, and requires no account or API key.</p>
+      </div>
+      <div class="step">
+        <h3>2. Open Any Supported AI Chat</h3>
+        <p>Navigate to ChatGPT, Claude, Gemini, or any of the 18 supported platforms and have a conversation as you normally would.</p>
+      </div>
+      <div class="step">
+        <h3>3. Click the Export Button</h3>
+        <p>Click the AI Chat Exporter icon in your toolbar and select Markdown. The file downloads instantly to your default downloads folder, named after the conversation title.</p>
+      </div>
+    </section>
+
+    <section class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">What is Markdown?</button>
+        <div class="faq-answer"><p>Markdown is a lightweight plain-text formatting language created by John Gruber. It uses simple symbols like asterisks, hashes, and backticks to denote formatting. Because it is plain text, it is universally portable, future-proof, and supported by thousands of applications from note-takers to documentation generators.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Does it preserve code formatting?</button>
+        <div class="faq-answer"><p>Yes. Code blocks are exported as fenced code blocks with triple backticks and the correct language tag (e.g., python, javascript, rust). Inline code is wrapped in single backticks. This means syntax highlighting works automatically when the Markdown is rendered in tools like GitHub, Obsidian, Typora, or VS Code.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I use this with Obsidian?</button>
+        <div class="faq-answer"><p>Absolutely. Exported files are compatible with Obsidian out of the box. They use standard Markdown that Obsidian renders perfectly, including code blocks, math, tables, and links. You can drop them directly into your vault folder or use Obsidian's file import.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">What about LaTeX math?</button>
+        <div class="faq-answer"><p>Both inline math ($x^2$) and display math ($$E=mc^2$$) are exported as raw LaTeX notation. Obsidian with the MathJax plugin, Typora, and any Markdown renderer with KaTeX or MathJax support will render these correctly. The original LaTeX source is preserved so you can edit the formulas after export.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">How do I import into Notion?</button>
+        <div class="faq-answer"><p>Open Notion, create a new page or navigate to an existing one, and paste the Markdown content directly. Notion automatically detects Markdown formatting and converts it to native Notion blocks. Alternatively, use Notion's import feature to upload the .md file.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Is it free?</button>
+        <div class="faq-answer"><p>Yes, AI Chat Exporter is completely free and open-source under the MPL 2.0 license. There are no premium tiers, no paywalls, and no in-app purchases. The source code is publicly auditable on GitHub.</p></div>
+      </div>
+    </section>
+
+    <section class="related-pages">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="chatgpt-to-markdown.html" class="related-link">
+          <h3>ChatGPT to Markdown</h3>
+          <p>Export OpenAI ChatGPT conversations to clean Markdown files.</p>
+        </a>
+        <a href="claude-to-markdown.html" class="related-link">
+          <h3>Claude to Markdown</h3>
+          <p>Export Anthropic Claude conversations including extended thinking blocks.</p>
+        </a>
+        <a href="obsidian-export.html" class="related-link">
+          <h3>Obsidian Export</h3>
+          <p>Drop AI conversations directly into your Obsidian knowledge base.</p>
+        </a>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/obsidian-export.html
+++ b/docs/obsidian-export.html
@@ -47,7 +47,7 @@
     <div class="hero">
       <span class="badge">Obsidian Integration</span>
       <h1>AI Chat to Obsidian &mdash; Direct Vault Transfer</h1>
-      <p class="hero-subtitle">Send conversations from ChatGPT, Claude, Gemini and 15 other AI platforms straight into your Obsidian vault as clean Markdown notes. One click, no API keys, no copy-paste.</p>
+      <p class="hero-subtitle">Send conversations from ChatGPT, Claude, Gemini and 14 other AI platforms straight into your Obsidian vault as clean Markdown notes. One click, no API keys, no copy-paste.</p>
       <div class="cta-group">
         <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
         <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
@@ -66,28 +66,24 @@
       <p>The extension uses Obsidian's built-in URI protocol to create notes instantly. Here is what happens behind the scenes when you click the Obsidian transfer button:</p>
       <div class="steps">
         <div class="step">
-          <div class="step-number">1</div>
           <div class="step-content">
             <h3>Parse the Conversation</h3>
             <p>AI Chat Exporter reads the active conversation from the AI platform's page. It identifies message boundaries, extracts content, preserves code blocks with syntax highlighting, and captures LaTeX math expressions.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">2</div>
           <div class="step-content">
             <h3>Convert to Obsidian-Ready Markdown</h3>
             <p>The conversation is converted to clean Markdown with proper heading hierarchy, fenced code blocks with language tags, and KaTeX-compatible math delimiters. Platform-specific content like Claude Artifacts or ChatGPT Canvas outputs become organized sections.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">3</div>
           <div class="step-content">
             <h3>Sanitize the Filename</h3>
             <p>The conversation title is sanitized for use as an Obsidian filename. Special characters are stripped, and the title is truncated to 245 characters to stay within filesystem limits. The result is a clean, readable filename like <code>ChatGPT - Refactoring Python Auth - 2026-03-15.md</code>.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-number">4</div>
           <div class="step-content">
             <h3>Open Obsidian via URI</h3>
             <p>The extension constructs an <code>obsidian://new</code> URI with the filename, vault name, and formatted content. Obsidian opens automatically and creates the note in your configured vault. The note appears in your vault instantly, ready to link and tag.</p>
@@ -167,7 +163,7 @@
             <tr>
               <td><strong>Other Platforms</strong></td>
               <td>Copilot, Qwen, Mistral, Meta AI, NotebookLM, Google AI Studio, and 8 more</td>
-              <td>Core message structure preserved across all 18 supported platforms</td>
+              <td>Core message structure preserved across all 17 supported platforms</td>
             </tr>
           </tbody>
         </table>
@@ -354,8 +350,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/obsidian-export.html
+++ b/docs/obsidian-export.html
@@ -266,7 +266,7 @@
 
     <section class="content-section">
       <h2>Organizing Monthly and Weekly Exports in Obsidian</h2>
-      <p>While each export is a single conversation, you can use the filename template settings to organize many exports into a consistent vault structure. Setting the template to <code>AI/{platform}/{title}</code> places every conversation in platform-specific folders, letting you build a searchable archive one export at a time without manual file moves.</p>
+      <p>While each export is a single conversation, you can use the filename template settings to give every export a consistent, sortable name. Setting the template to <code>{platform} - {title} - {datetime}</code> produces flat filenames like <code>ChatGPT - React Hooks Debugging - 2026-09-09_14-30.md</code>, letting you build a searchable archive one export at a time without manual renaming.</p>
       <p>Because Obsidian indexes files on disk, saved exports land directly in your vault and become immediately searchable and linkable. This turns every exported conversation into a permanent headnote that connects to the rest of your knowledge base.</p>
     </section>
 
@@ -282,7 +282,7 @@
         <div class="faq-item">
           <button class="faq-question">Does it create folders inside Obsidian?</button>
           <div class="faq-answer">
-            <p>The basic Obsidian transfer creates notes at the root level of your vault. However, you can customize the output by using the Markdown export format and specifying a folder path in the filename template settings. For example, setting the template to <code>AI/{platform}/{title}</code> organizes notes into platform-specific folders.</p>
+            <p>The basic Obsidian transfer creates notes at the root level of your vault. To keep exports organized, configure the filename template to include the platform name and timestamp (e.g. <code>{platform} - {title} - {datetime}</code>), so every note has a unique, sortable name.</p>
           </div>
         </div>
         <div class="faq-item">

--- a/docs/obsidian-export.html
+++ b/docs/obsidian-export.html
@@ -1,0 +1,362 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Chat to Obsidian — Export Conversations Directly to Your Vault</title>
+  <meta name="description" content="Export ChatGPT, Claude, Gemini and other AI conversations directly to Obsidian as Markdown notes. One-click vault transfer. Free extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/obsidian-export.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/obsidian-export.html" />
+  <meta property="og:title" content="AI Chat to Obsidian — Export Conversations Directly to Your Vault" />
+  <meta property="og:description" content="Export ChatGPT, Claude, Gemini and other AI conversations directly to Obsidian as Markdown notes. One-click vault transfer. Free extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>&rsaquo;</span> <span>Obsidian Export</span></div>
+
+  <main>
+    <div class="hero">
+      <span class="badge">Obsidian Integration</span>
+      <h1>AI Chat to Obsidian &mdash; Direct Vault Transfer</h1>
+      <p class="hero-subtitle">Send conversations from ChatGPT, Claude, Gemini and 15 other AI platforms straight into your Obsidian vault as clean Markdown notes. One click, no API keys, no copy-paste.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <section class="content-section">
+      <h2>Why Export AI Conversations to Obsidian?</h2>
+      <p>Obsidian is the most popular personal knowledge management tool for researchers, developers, and writers. It gives you full control over your notes with local Markdown files, bidirectional linking, and a powerful plugin ecosystem. But Obsidian only works as well as the content you put into it.</p>
+      <p>Every day you have valuable conversations with AI assistants&mdash;code reviews, research summaries, brainstorming sessions, technical explanations, creative drafts. Without a way to capture these, they sit trapped inside web interfaces where they cannot be linked, searched alongside your other notes, or referenced months later.</p>
+      <p>AI Chat Exporter bridges this gap by converting AI conversations into well-formatted Markdown and sending them directly to your Obsidian vault using Obsidian's native <code>obsidian://new</code> URI scheme. No manual copy-paste. No file management. No third-party sync services.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>How the Obsidian Integration Works</h2>
+      <p>The extension uses Obsidian's built-in URI protocol to create notes instantly. Here is what happens behind the scenes when you click the Obsidian transfer button:</p>
+      <div class="steps">
+        <div class="step">
+          <div class="step-number">1</div>
+          <div class="step-content">
+            <h3>Parse the Conversation</h3>
+            <p>AI Chat Exporter reads the active conversation from the AI platform's page. It identifies message boundaries, extracts content, preserves code blocks with syntax highlighting, and captures LaTeX math expressions.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">2</div>
+          <div class="step-content">
+            <h3>Convert to Obsidian-Ready Markdown</h3>
+            <p>The conversation is converted to clean Markdown with proper heading hierarchy, fenced code blocks with language tags, and KaTeX-compatible math delimiters. Platform-specific content like Claude Artifacts or ChatGPT Canvas outputs become organized sections.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">3</div>
+          <div class="step-content">
+            <h3>Sanitize the Filename</h3>
+            <p>The conversation title is sanitized for use as an Obsidian filename. Special characters are stripped, and the title is truncated to 245 characters to stay within filesystem limits. The result is a clean, readable filename like <code>ChatGPT - Refactoring Python Auth - 2026-03-15.md</code>.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-number">4</div>
+          <div class="step-content">
+            <h3>Open Obsidian via URI</h3>
+            <p>The extension constructs an <code>obsidian://new</code> URI with the filename, vault name, and formatted content. Obsidian opens automatically and creates the note in your configured vault. The note appears in your vault instantly, ready to link and tag.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>What Gets Transferred</h2>
+      <p>AI Chat Exporter preserves the structure and formatting of your conversations so nothing is lost in transit:</p>
+      <div class="features-grid">
+        <div class="feature-card">
+          <h3>Full Message History</h3>
+          <p>Every user message and AI response is transferred in order. Role labels distinguish who said what. Timestamps are preserved where the platform provides them.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Code Blocks with Languages</h3>
+          <p>Fenced code blocks retain their language tags. Python, JavaScript, TypeScript, Rust, and dozens of other languages display with proper syntax highlighting in Obsidian's reading view.</p>
+        </div>
+        <div class="feature-card">
+          <h3>LaTeX Math Equations</h3>
+          <p>Block math (<code>$$...$$</code>) and inline math (<code>$...$</code>) are preserved with correct delimiters. Equations render natively in Obsidian when you have the MathJax or KaTeX plugin enabled.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Thinking and Reasoning Sections</h3>
+          <p>When Claude or ChatGPT shows its thinking process, the extension captures it and formats it as a collapsible blockquote in the Markdown output. You keep the reasoning trail without cluttering the main response.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Artifacts and Canvas Content</h3>
+          <p>Claude Artifacts and ChatGPT Canvas outputs are represented within the conversation flow. Code artifacts use fenced code blocks; document artifacts use inline Markdown. Canvas documents appear as clearly labeled placeholders (e.g. <code>[Canvas: title]</code>) so you know a Canvas document was part of the exchange.</p>
+        </div>
+        <div class="feature-card">
+          <h3>Tables and Structured Data</h3>
+          <p>Markdown tables generated by AI responses are transferred with their original column alignment and structure intact.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Platform-Specific Behavior</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Platform</th>
+              <th>Special Handling</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>ChatGPT</strong></td>
+              <td>Artifacts become labeled sections, Canvas captured as labeled placeholder, thinking process captured</td>
+              <td>Group conversations with multiple models are preserved with model attribution</td>
+            </tr>
+            <tr>
+              <td><strong>Claude</strong></td>
+              <td>Artifacts with version history, thinking blocks as collapsible callouts, tool use steps</td>
+              <td>Extended thinking is formatted as blockquotes for clean separation</td>
+            </tr>
+            <tr>
+              <td><strong>Gemini</strong></td>
+              <td>Code execution outputs, multi-modal responses, Google Workspace integrations</td>
+              <td>Large context windows mean long exports work well</td>
+            </tr>
+            <tr>
+              <td><strong>DeepSeek</strong></td>
+              <td>DeepThink reasoning sections, code generation with full context</td>
+              <td>Math-heavy conversations transfer with equations intact</td>
+            </tr>
+            <tr>
+              <td><strong>Perplexity</strong></td>
+              <td>Citations preserved as footnotes, source links maintained</td>
+              <td>Research threads become well-documented notes</td>
+            </tr>
+            <tr>
+              <td><strong>Other Platforms</strong></td>
+              <td>Copilot, Qwen, Mistral, Meta AI, NotebookLM, Google AI Studio, and 8 more</td>
+              <td>Core message structure preserved across all 18 supported platforms</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Why This Beats Manual Copy-Paste</h2>
+      <p>Manually copying a conversation into Obsidian sounds simple until you try it. You have to select the entire conversation, paste it into a new note, then fix the formatting&mdash;code blocks that lost their language tags, math that renders as raw text, tables that collapsed, images that did not transfer. For long conversations, this process can take 15-20 minutes per note.</p>
+      <p>AI Chat Exporter reduces this to a single click. The extension handles all formatting, creates proper Markdown structure, sanitizes the filename, and opens Obsidian with the note ready to save. A conversation that takes 20 minutes to format manually is exported and filed in under 5 seconds.</p>
+      <div class="callout callout-info">
+        <strong>Vault Configuration:</strong> Open the extension options page and enter your Obsidian vault name in the "Obsidian Vault Name" field. This must match the exact name of your vault as it appears in Obsidian. If you leave it blank, the extension defaults to your system's default vault.
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Comparison with Obsidian Plugins</h2>
+      <p>Several community plugins attempt to bridge AI platforms and Obsidian. Here is how they compare to AI Chat Exporter's approach:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Feature</th>
+              <th>Community Plugins</th>
+              <th>AI Chat Exporter</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>API key required</td>
+              <td>Usually yes (OpenAI API key, Anthropic API key)</td>
+              <td>No &mdash; works through the browser extension</td>
+            </tr>
+            <tr>
+              <td>Platforms supported</td>
+              <td>Typically 1-2 (the API provider)</td>
+              <td>17 platforms through DOM extraction</td>
+            </tr>
+            <tr>
+              <td>Captures full conversation</td>
+              <td>Only what the API returns</td>
+              <td>Full conversation as displayed in the browser</td>
+            </tr>
+            <tr>
+              <td>Artifacts / Canvas</td>
+              <td>Not supported</td>
+              <td>Artifacts represented as labeled sections; Canvas captured as labeled placeholder</td>
+            </tr>
+            <tr>
+              <td>Selective export</td>
+              <td>Entire conversation only</td>
+              <td>Choose specific messages or turns</td>
+            </tr>
+            <tr>
+              <td>Cost</td>
+              <td>API usage charges apply</td>
+              <td>Completely free</td>
+            </tr>
+            <tr>
+              <td>Other formats</td>
+              <td>Markdown only (in most cases)</td>
+              <td>Markdown, PDF, JSON, HTML, Word, PNG</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="callout callout-success">
+        <strong>No API keys needed.</strong> Because AI Chat Exporter reads conversations directly from the browser page, it does not require API access to any AI platform. This means zero cost, zero API rate limits, and zero risk of exposing your API keys.
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Setting Up the Obsidian URI Scheme</h2>
+      <p>The <code>obsidian://</code> URI scheme is a built-in feature of Obsidian. To use it with AI Chat Exporter, ensure the following:</p>
+      <ul>
+        <li><strong>Obsidian is installed</strong> on the same machine where you run the browser extension.</li>
+        <li><strong>The URI scheme is registered</strong>. On Windows and macOS, this happens automatically when Obsidian is installed. On Linux, you may need to register it manually via your desktop environment.</li>
+        <li><strong>Enter your vault name</strong> in the extension options. The vault name must match exactly, including capitalization and spaces. If your vault is called "My Knowledge Base", enter exactly that.</li>
+      </ul>
+      <p>When you click the Obsidian transfer button, the extension builds a URI like <code>obsidian://new?vault=My%20Vault&name=Note%20Title&content=...</code> and navigates to it. Obsidian intercepts the URI, creates the note with the given name and content, and opens it in the editor.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Worked Example: ChatGPT to Obsidian</h2>
+      <p>Here is a concrete walkthrough of exporting a ChatGPT conversation about Python async programming to an Obsidian vault called "Dev Notes":</p>
+      <ol>
+        <li>Open the ChatGPT conversation in Chrome or Firefox.</li>
+        <li>Click the AI Chat Exporter extension icon. The side panel opens showing the parsed conversation.</li>
+        <li>Click the Obsidian icon in the export toolbar.</li>
+        <li>The extension converts the conversation to Markdown. Code blocks retain their Python language tags. Inline code and function names are preserved.</li>
+        <li>A new tab opens with <code>obsidian://new?vault=Dev%20Notes&name=ChatGPT%20-%20Python%20Async%20Programming%20-%202026-09-08</code>.</li>
+        <li>Obsidian creates the note in your "Dev Notes" vault. The note appears in your file explorer with all code blocks, headers, and formatted content intact.</li>
+      </ol>
+      <p>The entire process takes less than 5 seconds. You can now link to this note from other notes, add tags like <code>#python</code> and <code>#async</code>, and search for it alongside all your other knowledge base content.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Organizing Monthly and Weekly Exports in Obsidian</h2>
+      <p>While each export is a single conversation, you can use the filename template settings to organize many exports into a consistent vault structure. Setting the template to <code>AI/{platform}/{title}</code> places every conversation in platform-specific folders, letting you build a searchable archive one export at a time without manual file moves.</p>
+      <p>Because Obsidian indexes files on disk, saved exports land directly in your vault and become immediately searchable and linkable. This turns every exported conversation into a permanent headnote that connects to the rest of your knowledge base.</p>
+    </section>
+
+    <section class="content-section">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq">
+        <div class="faq-item">
+          <button class="faq-question">How do I configure my vault name?</button>
+          <div class="faq-answer">
+            <p>Open the AI Chat Exporter extension options page (right-click the extension icon and select "Options"). Find the "Obsidian Vault Name" field and enter the exact name of your target vault. The name must match what appears in Obsidian's vault switcher, including capitalization and spaces. If you have multiple vaults, you can switch the vault name before each transfer.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Does it create folders inside Obsidian?</button>
+          <div class="faq-answer">
+            <p>The basic Obsidian transfer creates notes at the root level of your vault. However, you can customize the output by using the Markdown export format and specifying a folder path in the filename template settings. For example, setting the template to <code>AI/{platform}/{title}</code> organizes notes into platform-specific folders.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Can I export images to Obsidian?</button>
+          <div class="faq-answer">
+            <p>AI Chat Exporter embeds images as data URIs or base64-encoded content within the Markdown file. Obsidian supports embedded images in notes, so inline images from conversations will display correctly. External image URLs that require network access may not render if Obsidian is configured for strict CSP mode.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">What happens to Artifacts when exported to Obsidian?</button>
+          <div class="faq-answer">
+            <p>Claude Artifacts are represented as labeled sections within the conversation note. Code artifacts use fenced code blocks with the appropriate language tag. Document artifacts are converted to Markdown inline. ChatGPT Canvas outputs appear as labeled placeholders (e.g. <code>[Canvas: title]</code>) within the conversation flow. The artifacts are part of the conversation flow rather than separate files.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">Does this work with Logseq, Bear, or other Markdown apps?</button>
+          <div class="faq-answer">
+            <p>Yes. AI Chat Exporter supports five personal knowledge management apps through URI schemes: Obsidian, Logseq, Bear, NotePlan, and Drafts. Each app has its own URI protocol. The extension lets you configure which app to target in the options page. Export to Markdown also works with any app that reads .md files.</p>
+          </div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-question">What if the URI scheme is not working?</button>
+          <div class="faq-answer">
+            <p>Ensure Obsidian is installed on your machine (not just running in a browser). On Linux, the URI scheme may need manual registration. On Windows and macOS, it registers automatically during Obsidian installation. If the URI still fails, fall back to the Markdown export and manually place the file in your vault folder.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="claude-to-obsidian.html" class="related-link">
+          <h3>Claude to Obsidian</h3>
+          <p>Export Claude conversations with Artifacts and Thinking blocks directly to Obsidian.</p>
+        </a>
+        <a href="markdown-exporter.html" class="related-link">
+          <h3>Markdown Exporter</h3>
+          <p>Full guide to Markdown export with code highlighting, math, and formatting details.</p>
+        </a>
+        <a href="chatgpt-to-markdown.html" class="related-link">
+          <h3>ChatGPT to Markdown</h3>
+          <p>Export ChatGPT conversations as clean, linkable Markdown files.</p>
+        </a>
+        <a href="latex-export.html" class="related-link">
+          <h3>LaTeX Math Export</h3>
+          <p>Preserve equations and math expressions when exporting to Obsidian or other apps.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="content-section">
+      <div class="callout callout-success">
+        <strong>Ready to connect your AI conversations to your Obsidian vault?</strong> Install AI Chat Exporter and start transferring conversations in one click. No API keys. No configuration beyond your vault name. Your notes, your vault, your control.
+        <div class="cta-group">
+          <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+          <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/pdf-exporter.html
+++ b/docs/pdf-exporter.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Chat to PDF — Export Any AI Conversation as PDF</title>
+  <meta name="description" content="Export conversations from ChatGPT, Claude, Gemini and more to PDF with custom themes, page breaks, and table of contents. Free extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/pdf-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/pdf-exporter.html" />
+  <meta property="og:title" content="AI Chat to PDF — Export Any AI Conversation as PDF" />
+  <meta property="og:description" content="Export conversations from ChatGPT, Claude, Gemini and more to PDF with custom themes, page breaks, and table of contents. Free extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>›</span> PDF Export</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Print Ready</span>
+      <h1>AI Chat to PDF — Print-Ready Conversation Exports</h1>
+      <p class="hero-subtitle">Convert AI conversations from ChatGPT, Claude, Gemini, and 15+ platforms into print-optimized PDF files with custom themes, page breaks, and a table of contents.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <section class="features-grid">
+      <div class="feature-card">
+        <h3>Print-Optimized Layout</h3>
+        <p>PDF export generates a print-ready HTML document and opens the browser's native print dialog. Margins, page breaks, and typography are tuned for clean A4 and Letter output.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Dark and Light Themes</h3>
+        <p>Choose between dark and light color themes for your PDF. The dark theme works well for screen viewing and projectors, while the light theme is optimized for ink-efficient printing.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Page Breaks per Prompt</h3>
+        <p>Enable page breaks between conversation turns so each prompt-response pair starts on a new page. This makes long conversations easy to navigate when printed or reviewed as a document.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Table of Contents</h3>
+        <p>Generate a table of contents at the top of the PDF with clickable page references. Each user prompt becomes a TOC entry, giving you a structured overview of the conversation.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Math Renders Correctly</h3>
+        <p>LaTeX math is rendered into crisp vector graphics using KaTeX before PDF generation. Inline and display equations appear exactly as they do in the original AI interface.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Highlighted Code Blocks</h3>
+        <p>Code blocks retain syntax highlighting in the PDF output. Language-specific coloring makes code readable and scannable, even in a printed document.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>How PDF Export Works</h2>
+      <p>AI Chat Exporter does not send your conversation to a server to generate a PDF. Instead, it constructs a self-contained HTML document from the conversation data, applies print-optimized CSS, and then invokes the browser's built-in print dialog. From the print dialog, you choose "Save as PDF" to produce the final file.</p>
+      <p>This approach has several advantages. First, your data never leaves your browser. Second, the PDF quality is identical to what you see on screen because it uses the same rendering engine. Third, there is no file-size limit — the PDF scales to conversations of any length.</p>
+      <p>The generated HTML is self-contained. Fonts, styles, math rendering, and images are all embedded. When you save the PDF, it is a single portable file that looks the same on any device.</p>
+    </section>
+
+    <section>
+      <h2>Customization Options</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr><th>Option</th><th>Description</th><th>Default</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Color Theme</td><td>Light or dark background for the PDF</td><td>Light</td></tr>
+            <tr><td>Page Breaks</td><td>Insert a page break before each new prompt</td><td>Off</td></tr>
+            <tr><td>Table of Contents</td><td>Generate a clickable TOC at the top of the document</td><td>Off</td></tr>
+            <tr><td>Page Size</td><td>A4 or Letter — controlled through the print dialog</td><td>A4</td></tr>
+            <tr><td>Margins</td><td>Adjustable through the browser print dialog (normal, narrow, wide)</td><td>Normal</td></tr>
+            <tr><td>Header/Footer</td><td>Browser print options for page numbers, dates, and URLs</td><td>Varies</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>To access these options, click the AI Chat Exporter icon while on a supported chat page and select the PDF export option. The settings panel appears before the print dialog opens, so you can preview the layout and adjust as needed.</p>
+    </section>
+
+    <section>
+      <h2>Use Cases for PDF Export</h2>
+      <p><strong>Archiving and Compliance</strong> — Many organizations require conversations with AI tools to be archived in a non-editable, universally readable format. PDF is the standard for long-term document preservation and meets most compliance requirements.</p>
+      <p><strong>Sharing with Non-Technical Colleagues</strong> — Not everyone has Markdown editors or Obsidian installed. A PDF file opens on any device with a browser. Share AI-generated research, brainstorming sessions, or technical explanations as attachments without worrying about compatibility.</p>
+      <p><strong>Presentations and Reports</strong> — Embed PDF pages from AI conversations into slide decks, reports, and proposals. The print-optimized layout ensures the content looks professional when included in formal documents.</p>
+      <p><strong>Printing</strong> — Sometimes you need a physical copy. The light theme is optimized for ink-efficient printing, and page breaks per prompt keep each exchange on its own page for easy annotation with a pen.</p>
+      <p><strong>Client Deliverables</strong> — If you use AI tools as part of client work, a PDF export provides a clean, branded-looking document you can deliver alongside your work products.</p>
+    </section>
+
+    <section>
+      <h2>Quality You Can Trust</h2>
+      <p>The PDF export preserves visual fidelity from the original conversation. Here is what that means in practice:</p>
+      <p>Mathematical equations render through KaTeX before the print dialog opens, so they appear as sharp vector graphics rather than pixelated screenshots. Code blocks use monospace fonts with proper indentation and syntax highlighting colors that remain readable in print. Tables retain their grid structure with clear column alignment.</p>
+      <p>Images from AI conversations — diagrams, charts, and generated visuals — are embedded in the PDF at their original resolution. The PDF does not compress or downsample these images.</p>
+    </section>
+
+    <section>
+      <h2>Supported Platforms</h2>
+      <p>PDF export works with all 17 platforms supported by AI Chat Exporter, including ChatGPT, Claude, Gemini, DeepSeek, Perplexity, Copilot, Qwen, Mistral, Meta AI, NotebookLM, Google AI Studio, Google Cloud Assist, Google Search AI, Z.AI, Proton Lumo, Joyland, and Chub.</p>
+    </section>
+
+    <section class="steps">
+      <h2>How to Export AI Chats to PDF</h2>
+      <div class="step">
+        <h3>1. Install the Extension</h3>
+        <p>Add AI Chat Exporter from the Chrome Web Store or Firefox Add-ons. It is free and requires no account, API key, or configuration.</p>
+      </div>
+      <div class="step">
+        <h3>2. Open Any Supported AI Chat</h3>
+        <p>Start or continue a conversation on any of the 18 supported AI platforms. The extension detects the active chat page automatically.</p>
+      </div>
+      <div class="step">
+        <h3>3. Click Export and Choose Settings</h3>
+        <p>Click the extension icon, select PDF, and adjust your theme, page break, and TOC preferences. The browser print dialog opens — click "Save" to download the PDF.</p>
+      </div>
+    </section>
+
+    <section class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">How do I save as PDF?</button>
+        <div class="faq-answer"><p>Click the AI Chat Exporter toolbar icon on a supported AI chat page, then select the PDF export option. The browser's print dialog opens with "Save as PDF" pre-selected as the destination. Click Save and choose where to store the file. The entire process takes a few seconds.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I customize the layout?</button>
+        <div class="faq-answer"><p>Yes. Before the print dialog opens, the extension provides options for color theme (light or dark), page breaks between prompts, and a table of contents. Additional layout controls like margins and page size are available through the browser's print dialog settings.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Does math render in the PDF?</button>
+        <div class="faq-answer"><p>Yes. LaTeX math notation is rendered through KaTeX into vector graphics before the PDF is generated. Both inline ($...$) and display ($$...$$) equations appear as crisp, scalable math in the final document.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Is there a page limit?</button>
+        <div class="faq-answer"><p>No. The PDF export scales to conversations of any length. Very long conversations may take slightly longer to render before the print dialog appears, but there is no artificial limit. The browser's print engine handles multi-page documents natively.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">How do I get dark mode PDFs?</button>
+        <div class="faq-answer"><p>Select the dark theme option in the PDF export settings panel. This produces a PDF with a dark background and light text, which is ideal for on-screen reading, presentations, and projectors. For printing on paper, the light theme is recommended to conserve ink.</p></div>
+      </div>
+    </section>
+
+    <section class="related-pages">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="chatgpt-to-pdf.html" class="related-link">
+          <h3>ChatGPT to PDF</h3>
+          <p>Export OpenAI ChatGPT conversations to print-ready PDF documents.</p>
+        </a>
+        <a href="markdown-exporter.html" class="related-link">
+          <h3>Markdown Export</h3>
+          <p>Export to portable Markdown files for note-taking and documentation workflows.</p>
+        </a>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/pdf-exporter.html
+++ b/docs/pdf-exporter.html
@@ -45,7 +45,7 @@
     <div class="hero">
       <span class="badge">Print Ready</span>
       <h1>AI Chat to PDF — Print-Ready Conversation Exports</h1>
-      <p class="hero-subtitle">Convert AI conversations from ChatGPT, Claude, Gemini, and 15+ platforms into print-optimized PDF files with custom themes, page breaks, and a table of contents.</p>
+      <p class="hero-subtitle">Convert AI conversations from all 17 supported platforms into print-optimized PDF files with custom themes, page breaks, and a table of contents.</p>
       <div class="cta-group">
         <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
         <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>

--- a/docs/pdf-exporter.html
+++ b/docs/pdf-exporter.html
@@ -135,7 +135,7 @@
       </div>
       <div class="step">
         <h3>2. Open Any Supported AI Chat</h3>
-        <p>Start or continue a conversation on any of the 18 supported AI platforms. The extension detects the active chat page automatically.</p>
+        <p>Start or continue a conversation on any of the 17 supported AI platforms. The extension detects the active chat page automatically.</p>
       </div>
       <div class="step">
         <h3>3. Click Export and Choose Settings</h3>
@@ -190,8 +190,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/perplexity-exporter.html
+++ b/docs/perplexity-exporter.html
@@ -216,8 +216,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/perplexity-exporter.html
+++ b/docs/perplexity-exporter.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Perplexity Exporter — Export Perplexity AI Conversations to Markdown</title>
+  <meta name="description" content="Export Perplexity AI conversations with sources and citations intact. Markdown, PDF, JSON, HTML, Word, PNG. Free browser extension." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/perplexity-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/perplexity-exporter.html" />
+  <meta property="og:title" content="Perplexity Exporter — Export Perplexity AI Conversations to Markdown" />
+  <meta property="og:description" content="Export Perplexity AI conversations with sources and citations intact. Markdown, PDF, JSON, HTML, Word, PNG. Free browser extension." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>›</span> Perplexity Exporter</div>
+  <main>
+    <div class="hero">
+      <span class="badge">Keeps Citations</span>
+      <h1>Perplexity Exporter — Preserve Your Research</h1>
+      <p class="hero-subtitle">Export Perplexity AI conversations with sources, citations, and search results intact. Save research threads as Markdown, JSON, HTML, PDF, Word, or PNG.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <h2>Why Perplexity Conversations Need Special Handling</h2>
+    <p>Perplexity AI is fundamentally different from other chatbots. Every answer includes inline citations that reference specific web sources. These citations are what make Perplexity useful for research, but they are also the first thing lost when you try to save a conversation manually. Copying and pasting a Perplexity answer gives you the text, but the superscript citation numbers become orphaned and the linked source URLs disappear entirely.</p>
+    <p>Researchers, journalists, students, and professionals use Perplexity daily for literature reviews, fact-checking, market research, and technical documentation. These users need the full context of where information came from, not just the synthesized answer. Losing citations means losing the ability to verify claims or follow up on sources.</p>
+
+    <h2>How the Parser Preserves Citations</h2>
+    <p>AI Chat Exporter's Perplexity parser understands the specific DOM structure that Perplexity uses to render citations. Rather than scraping raw text, the parser walks the DOM tree and extracts each citation as a structured element.</p>
+    <div class="features-grid">
+      <div class="feature-card">
+        <h4>Inline Citation Links</h4>
+        <p>Citation numbers in the text are converted to clickable hyperlinks in HTML and Markdown exports. Each link points to the original source URL that Perplexity referenced.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Source Blocks</h4>
+        <p>The source panels that Perplexity displays alongside answers are captured as a structured list at the end of each response. Titles, URLs, and domain names are preserved.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Search Queries</h4>
+        <p>Perplexity's internal search queries and the number of sources consulted are captured when visible in the UI, giving you a record of the research methodology.</p>
+      </div>
+      <div class="feature-card">
+        <h4>Thread Structure</h4>
+        <p>Multi-turn follow-up questions maintain their context. Each exchange is labeled with the question you asked and the full answer with all citations intact.</p>
+      </div>
+    </div>
+
+    <h2>Use Cases for Perplexity Export</h2>
+    <p>Exporting Perplexity conversations serves several practical purposes beyond simple backup.</p>
+    <ul>
+      <li><strong>Research documentation:</strong> Keep a permanent record of research threads with all source URLs preserved. Useful for academic papers, reports, and internal documentation.</li>
+      <li><strong>Academic reference:</strong> Students and researchers can archive literature reviews and fact-finding sessions with full citation trails for later verification.</li>
+      <li><strong>Source sharing:</strong> Send a well-researched Perplexity conversation to colleagues as a Markdown or PDF file with all sources clickable and verifiable.</li>
+      <li><strong>Audit trail:</strong> Document the sources that informed a decision or recommendation. Useful for compliance-sensitive industries where you need to show where information came from.</li>
+      <li><strong>Offline access:</strong> Save research threads before Perplexity's free tier limits or conversation cleanup removes them.</li>
+    </ul>
+
+    <h2>Export Formats for Perplexity</h2>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Format</th>
+            <th>Citation Handling</th>
+            <th>Best Use Case</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Markdown</strong></td>
+            <td>Inline links with source list</td>
+            <td>Note-taking, Obsidian, documentation</td>
+          </tr>
+          <tr>
+            <td><strong>JSON</strong></td>
+            <td>Structured citation objects with URLs</td>
+            <td>Data processing, API integration</td>
+          </tr>
+          <tr>
+            <td><strong>HTML</strong></td>
+            <td>Clickable superscript links</td>
+            <td>Web archives, readable backups</td>
+          </tr>
+          <tr>
+            <td><strong>PDF</strong></td>
+            <td>Numbered references with URLs</td>
+            <td>Printed records, formal reports</td>
+          </tr>
+          <tr>
+            <td><strong>Word (.doc)</strong></td>
+            <td>Hyperlinked footnotes</td>
+            <td>Collaboration, editing</td>
+          </tr>
+          <tr>
+            <td><strong>PNG Image</strong></td>
+            <td>Rendered as visual</td>
+            <td>Social sharing, screenshots</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>How to Export a Perplexity Conversation</h2>
+    <div class="steps">
+      <div class="step">
+        <div class="step-content">
+          <h4>Install the Extension</h4>
+          <p>Add AI Chat Exporter from the Chrome Web Store or Firefox Add-ons. It works immediately on Perplexity with no configuration.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Open Your Perplexity Thread</h4>
+          <p>Navigate to perplexity.ai and open the research thread you want to save. The parser handles both Standard and Pro search results.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Click the Extension Icon</h4>
+          <p>Click the AI Chat Exporter icon in your browser toolbar. The extension reads the current conversation and presents export options.</p>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-content">
+          <h4>Export with Citations</h4>
+          <p>Choose your format. Citation links are automatically included in the output. The file downloads to your machine instantly.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout callout-success">
+      <p><strong>Tip:</strong> For the cleanest Markdown output, export right after Perplexity finishes loading all source panels. If the sources panel is still loading when you export, some citations may be incomplete.</p>
+    </div>
+
+    <div class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">Does it keep source links from Perplexity?</button>
+        <div class="faq-answer">
+          <p>Yes. Every citation that Perplexity renders as a linked element is extracted with its full URL. In Markdown and HTML output, citation numbers become clickable hyperlinks. In JSON, each citation is a structured object with the source title and URL.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I export the cited URLs separately?</button>
+        <div class="faq-answer">
+          <p>The JSON format gives you structured access to each citation URL programmatically. For other formats, source URLs are embedded as hyperlinks that you can extract with standard tools. There is no dedicated "URLs only" export mode, but the JSON output makes programmatic extraction straightforward.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Does it work with Perplexity Pro searches?</button>
+        <div class="faq-answer">
+          <p>Yes. Both Standard and Pro search modes are supported. The parser captures whatever Perplexity renders in the DOM, including the additional reasoning and deeper source sets that Pro searches produce.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Does it handle Perplexity Collections?</button>
+        <div class="faq-answer">
+          <p>AI Chat Exporter exports individual Perplexity conversations, not entire Collections. To export a Collection, open each thread within the Collection and export it separately. We are evaluating Collection-level export for a future update.</p>
+        </div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Is my research data kept private?</button>
+        <div class="faq-answer">
+          <p>Completely. The extension processes everything locally in your browser. No conversation data, search queries, or citations are sent to any external server. The extension has no analytics, no telemetry, and no backend infrastructure.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="related-pages">
+      <h3>Other Exporters You Might Need</h3>
+      <div class="related-grid">
+        <a href="chatgpt-exporter.html" class="related-link">ChatGPT Exporter</a>
+        <a href="markdown-exporter.html" class="related-link">Markdown Exporter</a>
+        <a href="ai-chat-backup.html" class="related-link">AI Chat Backup</a>
+      </div>
+    </div>
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/png-exporter.html
+++ b/docs/png-exporter.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Chat to PNG — Export Conversations as Shareable Images</title>
+  <meta name="description" content="Export AI conversations as high-quality PNG images with 12 theme options. Perfect for sharing on social media, presentations, and documentation." />
+  <link rel="canonical" href="https://ai-chat-exporter.covai.org/png-exporter.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://ai-chat-exporter.covai.org/png-exporter.html" />
+  <meta property="og:title" content="AI Chat to PNG — Export Conversations as Shareable Images" />
+  <meta property="og:description" content="Export AI conversations as high-quality PNG images with 12 theme options. Perfect for sharing on social media, presentations, and documentation." />
+  <meta property="og:image" content="https://ai-chat-exporter.covai.org/og-image.png" />
+  <meta property="og:site_name" content="AI Chat Exporter" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/seo-pages.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "AI Chat Exporter",
+    "operatingSystem": "Chrome, Firefox, Edge",
+    "applicationCategory": "UtilitiesApplication",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "url": "https://ai-chat-exporter.covai.org/",
+    "downloadUrl": "https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj"
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <a href="index.html" class="logo-container">
+      <img src="icons/icon48.png" alt="AI Chat Exporter Logo" class="logo-img" />
+      <span class="logo-text">AI Chat Exporter</span>
+    </a>
+    <nav class="nav-links">
+      <a href="index.html" class="nav-link">Home</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" class="nav-link" target="_blank" rel="noopener">GitHub</a>
+    </nav>
+  </header>
+  <div class="breadcrumb"><a href="index.html">Home</a> <span>›</span> PNG Export</div>
+  <main>
+    <div class="hero">
+      <span class="badge">12 Themes</span>
+      <h1>AI Chat to PNG — Shareable Conversation Images</h1>
+      <p class="hero-subtitle">Export AI conversations as high-resolution PNG images with 12 curated color themes. Built for social sharing, presentations, and visual documentation.</p>
+      <div class="cta-group">
+        <a href="https://chromewebstore.google.com/detail/cgakhbhkplndjjknhgegfcipffflcaoj" class="btn btn-primary" target="_blank" rel="noopener">Add to Chrome</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/ai-chat-export/" class="btn btn-secondary" target="_blank" rel="noopener">Add to Firefox</a>
+      </div>
+    </div>
+
+    <section class="features-grid">
+      <div class="feature-card">
+        <h3>12 Curated Themes</h3>
+        <p>Choose from modern-light, modern-dark, github-light, github-dark, nord, dracula, solarized-light, solarized-dark, catppuccin, monokai, synthwave, and gruvbox. Each theme is hand-tuned for readability and visual appeal.</p>
+      </div>
+      <div class="feature-card">
+        <h3>2x High Resolution</h3>
+        <p>Enable the high-quality rendering option for 2x pixel density. The output looks crisp on Retina displays, in presentations, and when shared on social media platforms that compress images.</p>
+      </div>
+      <div class="feature-card">
+        <h3>KaTeX Math in Images</h3>
+        <p>Mathematical expressions are rendered through KaTeX before the image capture, so equations appear as sharp text in the PNG rather than broken notation or screenshots of the original.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Selective Capture</h3>
+        <p>Capture individual messages or entire conversation sections as separate images. This is useful when you want to share a specific AI response without including the full conversation context.</p>
+      </div>
+      <div class="feature-card">
+        <h3>Syntax Highlighted Code</h3>
+        <p>Code blocks in the image retain their syntax highlighting colors and monospace font. The code is readable even when the image is viewed at smaller sizes on mobile screens.</p>
+      </div>
+      <div class="feature-card">
+        <h3>No Watermarks</h3>
+        <p>PNG exports are clean images with no branding, watermarks, or overlays added by the extension. The output is purely your conversation content rendered in your chosen theme.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>How PNG Export Works</h2>
+      <p>AI Chat Exporter uses html2canvas to capture the conversation DOM as a pixel-perfect image. Before capture, the extension applies the selected theme's CSS, renders all math through KaTeX, and ensures code blocks are properly highlighted. The result is a PNG that faithfully reproduces the visual appearance of the conversation.</p>
+      <p>The rendering happens entirely in your browser. No data is sent to any server for image processing. The html2canvas library reads the rendered DOM and draws it to an off-screen canvas, which is then exported as a PNG file and downloaded to your machine.</p>
+      <p>For conversations with many messages, the extension captures the full scrollable height of the conversation content, producing a tall image that contains the complete exchange. The high-resolution option doubles the pixel dimensions for sharper output.</p>
+    </section>
+
+    <section>
+      <h2>Available Themes</h2>
+      <p>Each theme provides a complete visual palette including background, text, code block, heading, link, and border colors. Here is the full list of 12 themes:</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr><th>Theme</th><th>Style</th><th>Best For</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>modern-light</td><td>Clean white with subtle borders</td><td>Printing, documents, general use</td></tr>
+            <tr><td>modern-dark</td><td>Deep gray with light text</td><td>Screenshots, presentations</td></tr>
+            <tr><td>github-light</td><td>GitHub's light code theme</td><td>Technical sharing, documentation</td></tr>
+            <tr><td>github-dark</td><td>GitHub's dark code theme</td><td>Developer presentations</td></tr>
+            <tr><td>nord</td><td>Arctic blue-gray palette</td><td>Minimalist aesthetics</td></tr>
+            <tr><td>dracula</td><td>Purple-pink pastel on dark</td><td>Social media, visual impact</td></tr>
+            <tr><td>solarized-light</td><td>Warm cream background</td><td>Extended reading</td></tr>
+            <tr><td>solarized-dark</td><td>Dark teal background</td><td>Screens, projectors</td></tr>
+            <tr><td>catppuccin</td><td>Soft pastel on dark mauve</td><td>Modern developer aesthetic</td></tr>
+            <tr><td>monokai</td><td>High-contrast warm dark</td><td>Code-heavy conversations</td></tr>
+            <tr><td>synthwave</td><td>Neon retro-futurism</td><td>Social media, visual flair</td></tr>
+            <tr><td>gruvbox</td><td>Warm retro dark with oranges</td><td>Cozy aesthetic, code</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>High-Resolution Rendering</h2>
+      <p>The standard export produces a 1x image suitable for most use cases. When you enable the high-quality option, the extension renders at 2x pixel density, effectively doubling the resolution in each dimension. This produces a sharper image that holds up well on:</p>
+      <p>High-DPI monitors and Retina displays, where standard-resolution images appear blurry. Social media platforms like Twitter and LinkedIn, which compress uploaded images and benefit from higher source resolution. Printed materials and slide decks, where images are often scaled up from their original size.</p>
+      <p>Higher-resolution images are larger in file size. For conversations with many messages, the 2x option may produce images several megabytes in size. Use the standard resolution for quick shares and the high-quality option for polished deliverables.</p>
+    </section>
+
+    <section>
+      <h2>Selective Export</h2>
+      <p>You do not always want to capture an entire conversation as one image. The selective capture feature lets you choose specific messages or sections. This is useful when:</p>
+      <p>You want to share a single AI response on social media without the preceding prompts. You need to highlight a particular code block or table from a longer exchange. You are building documentation and want to capture individual Q&A pairs as separate images.</p>
+      <p>To use selective capture, click the extension icon, select PNG, and then choose which messages to include. The image renders only the selected content with consistent spacing and theme application.</p>
+    </section>
+
+    <section>
+      <h2>Use Cases</h2>
+      <p><strong>Social Media Sharing</strong> — AI conversations look polished as images on Twitter, LinkedIn, Reddit, and Hacker News. A themed PNG with syntax-highlighted code is far more visually engaging than a text paste or a plain screenshot.</p>
+      <p><strong>Documentation</strong> — Technical writers and developer advocates embed AI conversation images in blog posts, README files, and knowledge bases. The consistent theming makes the images look professional and on-brand.</p>
+      <p><strong>Presentations</strong> — Drop PNG exports directly into slide decks. Unlike screenshots of the AI interface, these images are themed, cropped to content, and free of browser chrome and UI distractions.</p>
+      <p><strong>Slack and Discord</strong> — Share AI-generated insights, code snippets, or explanations as images in team channels. The image renders inline in Slack and Discord, making it immediately visible without clicking through.</p>
+      <p><strong>Client Reports</strong> — When AI tools are part of your client workflow, PNG exports provide polished, presentable artifacts that can be included in deliverables without revealing your browser setup or platform UI.</p>
+    </section>
+
+    <section class="callout callout-success">
+      <h2>Supported Platforms</h2>
+      <p>PNG export works with all 17 platforms supported by AI Chat Exporter: ChatGPT, Claude, Gemini, DeepSeek, Perplexity, Copilot, Qwen, Mistral, Meta AI, NotebookLM, Google AI Studio, Google Cloud Assist, Google Search AI, Z.AI, Proton Lumo, Joyland, and Chub.</p>
+    </section>
+
+    <section class="steps">
+      <h2>How to Export AI Chats as PNG</h2>
+      <div class="step">
+        <h3>1. Install the Extension</h3>
+        <p>Add AI Chat Exporter from the Chrome Web Store or Firefox Add-ons. Free, open-source, no account or API key needed.</p>
+      </div>
+      <div class="step">
+        <h3>2. Open Any Supported AI Chat</h3>
+        <p>Navigate to a conversation on any of the 18 supported platforms. Ensure the messages you want to capture are visible in the chat window.</p>
+      </div>
+      <div class="step">
+        <h3>3. Select Theme and Export</h3>
+        <p>Click the toolbar icon, choose PNG, select your preferred theme, and optionally enable high resolution. The image downloads immediately as a PNG file.</p>
+      </div>
+    </section>
+
+    <section class="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="faq-item">
+        <button class="faq-question">How do I get high quality images?</button>
+        <div class="faq-answer"><p>Enable the high-resolution (2x) option in the PNG export settings before generating the image. This doubles the pixel density in both dimensions, producing a sharper image suitable for Retina displays, presentations, and social media where compression is applied.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Can I select which messages to capture?</button>
+        <div class="faq-answer"><p>Yes. The selective capture mode lets you choose specific messages or sections from the conversation to include in the image. This is ideal for sharing individual responses without exporting the entire conversation.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Does math render in the image?</button>
+        <div class="faq-answer"><p>Yes. LaTeX math is rendered through KaTeX before the image capture. Both inline and display equations appear as crisp, readable math in the PNG rather than broken LaTeX syntax or DOM artifacts.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">What themes are available?</button>
+        <div class="faq-answer"><p>There are 12 themes: modern-light, modern-dark, github-light, github-dark, nord, dracula, solarized-light, solarized-dark, catppuccin, monokai, synthwave, and gruvbox. Each theme provides a complete color palette optimized for readability and visual appeal.</p></div>
+      </div>
+      <div class="faq-item">
+        <button class="faq-question">Why is PNG export slow on long chats?</button>
+        <div class="faq-answer"><p>PNG export uses html2canvas to render the DOM to a canvas element. For conversations with many messages, the rendering process takes longer because the library must paint every element, including code blocks and images. High-resolution mode doubles the render time. For very long conversations, consider using selective capture to export only the relevant sections, or use Markdown export for a fast, text-based alternative.</p></div>
+      </div>
+    </section>
+
+    <section class="related-pages">
+      <h2>Related Pages</h2>
+      <div class="related-grid">
+        <a href="markdown-exporter.html" class="related-link">
+          <h3>Markdown Export</h3>
+          <p>Export to portable Markdown files for note-taking and documentation workflows.</p>
+        </a>
+        <a href="chatgpt-exporter.html" class="related-link">
+          <h3>ChatGPT Exporter</h3>
+          <p>Export conversations from OpenAI ChatGPT in multiple formats.</p>
+        </a>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="footer-links">
+      <a href="privacy.html">Privacy Policy</a>
+      <a href="license.html">License (MPL 2.0)</a>
+      <a href="https://github.com/Covai-Labs/ai-chat-exporter" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
+  </footer>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    });
+  </script>
+</body>
+</html>

--- a/docs/png-exporter.html
+++ b/docs/png-exporter.html
@@ -59,7 +59,7 @@
       </div>
       <div class="feature-card">
         <h3>2x High Resolution</h3>
-        <p>Enable the high-quality rendering option for 2x pixel density. The output looks crisp on Retina displays, in presentations, and when shared on social media platforms that compress images.</p>
+        <p>Enable the high-quality rendering option, which targets 2x pixel density. The output looks crisp on Retina displays, in presentations, and when shared on social media platforms that compress images.</p>
       </div>
       <div class="feature-card">
         <h3>KaTeX Math in Images</h3>
@@ -114,7 +114,7 @@
 
     <section>
       <h2>High-Resolution Rendering</h2>
-      <p>The standard export produces a 1x image suitable for most use cases. When you enable the high-quality option, the extension renders at 2x pixel density, effectively doubling the resolution in each dimension. This produces a sharper image that holds up well on:</p>
+      <p>The standard export produces a 1x image suitable for most use cases. When you enable the high-quality option, the extension targets 2x pixel density, effectively doubling the resolution in each dimension when your device and the conversation length allow it. For very long conversations, the renderer may fall back to a lower scale to stay within canvas memory limits. Either way you get a sharper image that holds up well on:</p>
       <p>High-DPI monitors and Retina displays, where standard-resolution images appear blurry. Social media platforms like Twitter and LinkedIn, which compress uploaded images and benefit from higher source resolution. Printed materials and slide decks, where images are often scaled up from their original size.</p>
       <p>Higher-resolution images are larger in file size. For conversations with many messages, the 2x option may produce images several megabytes in size. Use the standard resolution for quick shares and the high-quality option for polished deliverables.</p>
     </section>
@@ -148,7 +148,7 @@
       </div>
       <div class="step">
         <h3>2. Open Any Supported AI Chat</h3>
-        <p>Navigate to a conversation on any of the 18 supported platforms. Ensure the messages you want to capture are visible in the chat window.</p>
+        <p>Navigate to a conversation on any of the 17 supported platforms. Ensure the messages you want to capture are visible in the chat window.</p>
       </div>
       <div class="step">
         <h3>3. Select Theme and Export</h3>
@@ -160,7 +160,7 @@
       <h2>Frequently Asked Questions</h2>
       <div class="faq-item">
         <button class="faq-question">How do I get high quality images?</button>
-        <div class="faq-answer"><p>Enable the high-resolution (2x) option in the PNG export settings before generating the image. This doubles the pixel density in both dimensions, producing a sharper image suitable for Retina displays, presentations, and social media where compression is applied.</p></div>
+        <div class="faq-answer"><p>Enable the high-resolution (2x) option in the PNG export settings before generating the image. This targets double the pixel density in both dimensions, producing a sharper image suitable for Retina displays, presentations, and social media where compression is applied.</p></div>
       </div>
       <div class="faq-item">
         <button class="faq-question">Can I select which messages to capture?</button>
@@ -203,8 +203,22 @@
     <p>&copy; 2026 AI Chat Exporter. Open source under MPL 2.0.</p>
   </footer>
   <script>
-    document.querySelectorAll('.faq-question').forEach(btn => {
-      btn.addEventListener('click', () => btn.closest('.faq-item').classList.toggle('open'));
+    document.querySelectorAll('.faq-item').forEach((item, index) => {
+      const btn = item.querySelector('.faq-question');
+      const answer = item.querySelector('.faq-answer');
+      if (!btn || !answer) return;
+      const id = 'faq-' + (index + 1);
+      btn.id = 'q-' + id;
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-controls', id);
+      answer.id = id;
+      answer.setAttribute('role', 'region');
+      answer.setAttribute('aria-labelledby', 'q-' + id);
+      btn.addEventListener('click', () => {
+        const open = item.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        answer.setAttribute('aria-hidden', open ? 'false' : 'true');
+      });
     });
   </script>
 </body>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai-chat-exporter.covai.org/</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-09-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -11,6 +11,120 @@
     <lastmod>2026-08-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/chatgpt-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/chatgpt-to-markdown.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/chatgpt-to-pdf.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/claude-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/claude-to-markdown.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/claude-to-obsidian.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/gemini-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/gemini-to-markdown.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/deepseek-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/perplexity-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/copilot-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/markdown-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/pdf-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/json-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/png-exporter.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/obsidian-export.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/cross-ai-transfer.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/ai-chat-backup.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://ai-chat-exporter.covai.org/latex-export.html</loc>
+    <lastmod>2026-09-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ai-chat-exporter.covai.org/license.html</loc>


### PR DESCRIPTION
## Problem

The extension's website has only 6 pages (index, welcome, license, privacy, feedback, uninstall-feedback). Meanwhile, users are actively searching for task-specific queries ("chatgpt to markdown", "claude to obsidian", "export gemini conversation") and landing on competitor pages with keyword-rich names. Our extension was invisible for these high-intent searches.

## What this adds

19 new intent-specific landing pages in `docs/` (served at `ai-chat-exporter.covai.org/`) + one shared stylesheet (`docs/css/seo-pages.css`).

### Platform pages
- `chatgpt-exporter.html` · `claude-exporter.html` · `gemini-exporter.html`
- `deepseek-exporter.html` · `perplexity-exporter.html` · `copilot-exporter.html`

### Per-platform guides
- `chatgpt-to-markdown.html` · `chatgpt-to-pdf.html`
- `claude-to-markdown.html` · `claude-to-obsidian.html`
- `gemini-to-markdown.html`

### Format pages
- `markdown-exporter.html` · `pdf-exporter.html` · `json-exporter.html` · `png-exporter.html`

### Use-case pages
- `obsidian-export.html` · `cross-ai-transfer.html` · `ai-chat-backup.html` · `latex-export.html`

## SEO approach

- **JSON-LD SoftwareApplication schema** on every page (applicationCategory, offers, CWS/downloadUrl)
- **Canonical URLs** + **OpenGraph** tags pointing to `ai-chat-exporter.covai.org/`
- **sitemap.xml** updated with all 19 new URLs (priority 0.6-0.7, lastmod 2026-09-09)
- **robots.txt** already had sitemap reference -- no change needed
- **Breadcrumbs**, **FAQ accordions**, and **structured headings** (H1 > H2 > H3 hierarchy)
- Internal cross-linking: every page links to 2-3 related pages; `index.html` now has a Guides & How-To grid linking all 19 pages

## Claims verified against source code

Every factual claim was checked against `decant-core/ai/*.js` parsers and `ai-chat-exporter/` extension code before merge:

- Canvas: `[Canvas: title]` placeholder, not full export -- verified in `chatgpt.js:396-400`
- Gemini: no Canvas support, only Deep Research -- verified in `gemini.js`
- Claude Thinking Process captured as blockquote -- verified in `claude.js:409-410`
- Claude tool_use handling (widgets, repl, MCP) -- verified in `claude.js:375+`
- No bulk export / batch export feature -- confirmed absent via grep
- No thinking toggle in extension settings -- confirmed via `options/options.html`
- Platform count corrected to 17 (not 18) -- count of `decant-core/ai/index.js` exports
- Word format fixed to `.doc` (not `.docx`) -- verified in `_locales/en/messages.json:77`
- No token counts in JSON schema -- verified in `schemas/export-v1.schema.json`
- Continuation does not truncate messages -- verified in `content/formatters/continuation.js`
- Claude has no Projects / ZIP export -- removed fabricated claims
- 15 transfer targets -- verified in `background/background.js:15-31`

## Style

All pages use `docs/css/seo-pages.css` (no inline styles). Matches existing site dark theme (#0b111e background, Outfit font). No page exceeds 2,000 words; all provide genuine value and avoid keyword stuffing.

## QA

- All 19 pages parse cleanly (Python3 HTMLParser)
- All JSON-LD blocks valid JSON
- All internal hrefs resolve
- All canonical URLs match page filenames
- All 19 pages present in sitemap.xml
- Index.html Guides grid links all 19 pages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added 20 new guides covering AI conversation export, supported platforms, formats, backups, Obsidian, and cross-AI transfers.
  - Added dedicated landing pages for ChatGPT, Claude, Gemini, DeepSeek, Perplexity, Copilot, Markdown, PDF, JSON, PNG, LaTeX, and more.
  - Added interactive FAQ sections, installation guidance, comparisons, examples, and feature explanations across the new pages.
  - Added shared responsive styling for consistent navigation, layouts, tables, cards, and FAQs.

- **Documentation**
  - Updated the homepage with a new “Guides & How-To’s” section.
  - Updated the sitemap to include the new documentation and feature pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->