### PR TITLE
make export attribution optional

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -219,6 +219,10 @@
     "message": "Bilder standardmäßig in Exporte einschließen",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Hinweis \"Exported with AI Chat Exporter\" in Exporten einschließen",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Parser-Extraktionsmodus",
     "description": "Title for parser mode section"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -219,6 +219,10 @@
     "message": "Include images in exports by default",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Include \"Exported with AI Chat Exporter\" credit in exports",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Parser Extraction Mode",
     "description": "Title for parser mode section"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -219,6 +219,10 @@
     "message": "Incluir imágenes en las exportaciones por defecto",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Incluir el crédito \"Exported with AI Chat Exporter\" en las exportaciones",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Modo de extracción del analizador",
     "description": "Title for parser mode section"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -219,6 +219,10 @@
     "message": "Inclure les images dans les exports par défaut",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Inclure la mention \"Exported with AI Chat Exporter\" dans les exports",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Mode d'extraction de l'analyseur",
     "description": "Title for parser mode section"

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -219,6 +219,10 @@
     "message": "डिफ़ॉल्ट रूप से निर्यात में छवियां शामिल करें",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "निर्यात में \"Exported with AI Chat Exporter\" क्रेडिट शामिल करें",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "पार्सर निष्कर्षण मोड",
     "description": "Title for parser mode section"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -219,6 +219,10 @@
     "message": "Includi immagini nelle esportazioni per impostazione predefinita",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Includi la dicitura \"Exported with AI Chat Exporter\" nelle esportazioni",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Modalità di estrazione del parser",
     "description": "Title for parser mode section"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -219,6 +219,10 @@
     "message": "既定でエクスポートに画像を含める",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "エクスポートに「Exported with AI Chat Exporter」のクレジットを含める",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "パーサー抽出モード",
     "description": "Title for parser mode section"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -219,6 +219,10 @@
     "message": "내보낼 때 기본적으로 이미지 포함",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "내보내기에 \"Exported with AI Chat Exporter\" 크레딧 포함",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "파서 추출 모드",
     "description": "Title for parser mode section"

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -219,6 +219,10 @@
     "message": "Incluir imagens nas exportações por padrão",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Incluir o crédito \"Exported with AI Chat Exporter\" nas exportações",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Modo de extração do analisador",
     "description": "Title for parser mode section"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -220,7 +220,7 @@
     "description": "Label for default include images checkbox"
   },
   "includeAttributionDefault": {
-    "message": "Включать упоминание \"Exported with AI Chat Exporter\" в экспорт",
+    "message": "Включать упоминание \"Exported with AI Chat Exporter\" при экспорте",
     "description": "Label for default include attribution credit checkbox"
   },
   "parserModeTitle": {

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -219,6 +219,10 @@
     "message": "Включать изображения в экспорт по умолчанию",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Включать упоминание \"Exported with AI Chat Exporter\" в экспорт",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Режим извлечения парсера",
     "description": "Title for parser mode section"

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -219,6 +219,10 @@
     "message": "இயல்புநிலையாக ஏற்றுமதியில் படங்களைச் சேர்க்கவும்",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "ஏற்றுமதிகளில் \"Exported with AI Chat Exporter\" குறிப்பைச் சேர்க்கவும்",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "பிரித்தெடுத்தல் முறைமை (Parser Mode)",
     "description": "Title for parser mode section"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -219,6 +219,10 @@
     "message": "默认在导出的内容中包含图片",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "在导出中包含 \"Exported with AI Chat Exporter\" 署名",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "解析器提取模式",
     "description": "Title for parser mode section"

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -219,6 +219,10 @@
     "message": "預設在匯出內容中包含圖片",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "在匯出中包含 \"Exported with AI Chat Exporter\" 署名",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "解析器擷取模式",
     "description": "Title for parser mode section"

--- a/content/formatters/base.js
+++ b/content/formatters/base.js
@@ -1,3 +1,13 @@
+/**
+ * Determines whether attribution should be included based on formatter options.
+ * Attribution is included by default and only omitted when explicitly disabled.
+ * @param {{ includeAttribution?: boolean }} [options]
+ * @returns {boolean}
+ */
+export function shouldIncludeAttribution(options = {}) {
+  return options.includeAttribution !== false;
+}
+
 export class ExportFormatter {
   constructor() {}
 

--- a/content/formatters/doc.js
+++ b/content/formatters/doc.js
@@ -1,4 +1,4 @@
-import { ExportFormatter } from './base.js';
+import { ExportFormatter, shouldIncludeAttribution } from './base.js';
 import { markdownToHtml, escapeHtml } from './html.js';
 
 export class DocFormatter extends ExportFormatter {
@@ -13,7 +13,7 @@ export class DocFormatter extends ExportFormatter {
     const method = conversation.metadata?.Method || '';
 
     const metaParts = [`Exported from ${escapeHtml(platform)}`, formattedDate];
-    if (options.includeAttribution !== false) {
+    if (shouldIncludeAttribution(options)) {
       metaParts.push(
         '<a href="https://ai-chat-exporter.covai.org/" style="color: #64748b;">AI Chat Exporter</a>',
       );

--- a/content/formatters/doc.js
+++ b/content/formatters/doc.js
@@ -2,7 +2,7 @@ import { ExportFormatter } from './base.js';
 import { markdownToHtml, escapeHtml } from './html.js';
 
 export class DocFormatter extends ExportFormatter {
-  format(conversation) {
+  format(conversation, options = {}) {
     const { title, messages } = conversation;
     const now = new Date();
     const formattedDate = `${now.getMonth() + 1}/${now.getDate()}/${now.getFullYear()} ${now.toLocaleTimeString('en-US', { hour12: false })}`;
@@ -13,9 +13,11 @@ export class DocFormatter extends ExportFormatter {
     const method = conversation.metadata?.Method || '';
 
     const metaParts = [`Exported from ${escapeHtml(platform)}`, formattedDate];
-    metaParts.push(
-      '<a href="https://ai-chat-exporter.covai.org/" style="color: #64748b;">AI Chat Exporter</a>',
-    );
+    if (options.includeAttribution !== false) {
+      metaParts.push(
+        '<a href="https://ai-chat-exporter.covai.org/" style="color: #64748b;">AI Chat Exporter</a>',
+      );
+    }
     if (link) {
       metaParts.push(`<a href="${escapeHtml(link)}" style="color: #64748b;">Original Link</a>`);
     }

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -1,4 +1,4 @@
-import { ExportFormatter } from './base.js';
+import { ExportFormatter, shouldIncludeAttribution } from './base.js';
 import { sanitizeHtml } from '../utils/sanitizer.js';
 import { katexCss, katexJs, autoRenderJs, prismCss, prismJs } from '../lib/assets.js';
 
@@ -959,7 +959,7 @@ ${prismJs}
         <div class="metadata">
           <span class="badge">${escapeHtml(platform)}</span>
           <span class="meta-item">Exported: ${formattedDate}</span>
-          ${options.includeAttribution !== false ? `<span class="meta-item"><a href="https://ai-chat-exporter.covai.org/" target="_blank" style="color: inherit;">AI Chat Exporter</a></span>` : ''}
+          ${shouldIncludeAttribution(options) ? `<span class="meta-item"><a href="https://ai-chat-exporter.covai.org/" target="_blank" style="color: inherit;">AI Chat Exporter</a></span>` : ''}
           ${link ? `<span class="meta-item"><a href="${escapeHtml(link)}" target="_blank" style="color: inherit;">Original Link</a></span>` : ''}
           ${model ? `<span class="meta-item">Model: ${escapeHtml(model)}</span>` : ''}
           ${method ? `<span class="meta-item">Method: ${escapeHtml(method)}</span>` : ''}
@@ -974,7 +974,7 @@ ${prismJs}
     </main>
 
     ${
-      options.includeAttribution !== false
+      shouldIncludeAttribution(options)
         ? `
     <footer class="export-footer">
       <p>Exported with <a href="https://ai-chat-exporter.covai.org/" target="_blank" rel="noopener noreferrer">AI Chat Exporter</a></p>

--- a/content/formatters/html.js
+++ b/content/formatters/html.js
@@ -959,7 +959,7 @@ ${prismJs}
         <div class="metadata">
           <span class="badge">${escapeHtml(platform)}</span>
           <span class="meta-item">Exported: ${formattedDate}</span>
-          <span class="meta-item"><a href="https://ai-chat-exporter.covai.org/" target="_blank" style="color: inherit;">AI Chat Exporter</a></span>
+          ${options.includeAttribution !== false ? `<span class="meta-item"><a href="https://ai-chat-exporter.covai.org/" target="_blank" style="color: inherit;">AI Chat Exporter</a></span>` : ''}
           ${link ? `<span class="meta-item"><a href="${escapeHtml(link)}" target="_blank" style="color: inherit;">Original Link</a></span>` : ''}
           ${model ? `<span class="meta-item">Model: ${escapeHtml(model)}</span>` : ''}
           ${method ? `<span class="meta-item">Method: ${escapeHtml(method)}</span>` : ''}
@@ -973,9 +973,14 @@ ${prismJs}
       ${formattedMessages}
     </main>
 
+    ${
+      options.includeAttribution !== false
+        ? `
     <footer class="export-footer">
       <p>Exported with <a href="https://ai-chat-exporter.covai.org/" target="_blank" rel="noopener noreferrer">AI Chat Exporter</a></p>
-    </footer>
+    </footer>`
+        : ''
+    }
   </div>
 
   <script>

--- a/content/formatters/image.js
+++ b/content/formatters/image.js
@@ -1,6 +1,6 @@
 import html2canvas from 'html2canvas';
 import renderMathInElement from 'katex/dist/contrib/auto-render.mjs';
-import { ExportFormatter } from './base.js';
+import { ExportFormatter, shouldIncludeAttribution } from './base.js';
 import { markdownToHtml, escapeHtml } from './html.js';
 
 export const THEME_PALETTES = {
@@ -431,7 +431,7 @@ export class ImageFormatter extends ExportFormatter {
         </div>
         <div style="font-size: 12px; color: ${palette.subtitleColor}; text-align: right; white-space: nowrap; margin-left: 16px;">
           <div>${escapeHtml(formattedDate)}</div>
-          ${options.includeAttribution !== false ? `<div style="margin-top: 2px;"><a href="https://ai-chat-exporter.covai.org" target="_blank" style="color: ${palette.subtitleColor}; text-decoration: none;">AI Chat Exporter</a></div>` : ''}
+          ${shouldIncludeAttribution(options) ? `<div style="margin-top: 2px;"><a href="https://ai-chat-exporter.covai.org" target="_blank" style="color: ${palette.subtitleColor}; text-decoration: none;">AI Chat Exporter</a></div>` : ''}
         </div>
       </div>
 
@@ -441,7 +441,7 @@ export class ImageFormatter extends ExportFormatter {
       </div>
 
       ${
-        options.includeAttribution !== false
+        shouldIncludeAttribution(options)
           ? `
       <!-- Footer Watermark -->
       <div style="margin-top: 40px; border-top: 1px solid ${palette.borderColor}; padding-top: 16px; text-align: center; font-size: 12px; color: ${palette.subtitleColor};">

--- a/content/formatters/image.js
+++ b/content/formatters/image.js
@@ -431,7 +431,7 @@ export class ImageFormatter extends ExportFormatter {
         </div>
         <div style="font-size: 12px; color: ${palette.subtitleColor}; text-align: right; white-space: nowrap; margin-left: 16px;">
           <div>${escapeHtml(formattedDate)}</div>
-          <div style="margin-top: 2px;"><a href="https://ai-chat-exporter.covai.org" target="_blank" style="color: ${palette.subtitleColor}; text-decoration: none;">AI Chat Exporter</a></div>
+          ${options.includeAttribution !== false ? `<div style="margin-top: 2px;"><a href="https://ai-chat-exporter.covai.org" target="_blank" style="color: ${palette.subtitleColor}; text-decoration: none;">AI Chat Exporter</a></div>` : ''}
         </div>
       </div>
 
@@ -440,10 +440,15 @@ export class ImageFormatter extends ExportFormatter {
         ${formattedMessages}
       </div>
 
+      ${
+        options.includeAttribution !== false
+          ? `
       <!-- Footer Watermark -->
       <div style="margin-top: 40px; border-top: 1px solid ${palette.borderColor}; padding-top: 16px; text-align: center; font-size: 12px; color: ${palette.subtitleColor};">
         Exported with <strong>AI Chat Exporter</strong> • <span style="color: ${palette.accent};">https://ai-chat-exporter.covai.org/</span>
-      </div>
+      </div>`
+          : ''
+      }
     `;
 
     return container;

--- a/content/formatters/markdown.js
+++ b/content/formatters/markdown.js
@@ -96,14 +96,16 @@ export function extractBase64ImagesToReference(
 }
 
 export class MarkdownFormatter extends ExportFormatter {
-  format(conversation) {
+  format(conversation, options = {}) {
     const { title, messages } = conversation;
     const now = new Date();
     const formattedDate = `${now.getMonth() + 1}/${now.getDate()}/${now.getFullYear()} ${now.toLocaleTimeString('en-US', { hour12: false })}`;
 
     let output = `# ${title || 'AI Chat Export'}\n\n`;
 
-    output += `**Exported with:** [AI Chat Exporter](https://ai-chat-exporter.covai.org)  \n`;
+    if (options.includeAttribution !== false) {
+      output += `**Exported with:** [AI Chat Exporter](https://ai-chat-exporter.covai.org)  \n`;
+    }
 
     const metadata = conversation.metadata || {};
     const platform = metadata.Source || 'AI';

--- a/content/formatters/markdown.js
+++ b/content/formatters/markdown.js
@@ -1,4 +1,4 @@
-import { ExportFormatter } from './base.js';
+import { ExportFormatter, shouldIncludeAttribution } from './base.js';
 
 function cleanLatexMath(latex) {
   if (!latex || typeof latex !== 'string') return '';
@@ -103,7 +103,7 @@ export class MarkdownFormatter extends ExportFormatter {
 
     let output = `# ${title || 'AI Chat Export'}\n\n`;
 
-    if (options.includeAttribution !== false) {
+    if (shouldIncludeAttribution(options)) {
       output += `**Exported with:** [AI Chat Exporter](https://ai-chat-exporter.covai.org)  \n`;
     }
 

--- a/content/main.js
+++ b/content/main.js
@@ -176,6 +176,18 @@ function stripImages(content) {
   return cleaned;
 }
 
+async function getAttributionSetting() {
+  try {
+    const syncData = await chrome.storage.sync.get('includeAttribution');
+    if (syncData && syncData.includeAttribution !== undefined) {
+      return syncData.includeAttribution;
+    }
+  } catch {
+    // Ignore storage errors and fall back to the default
+  }
+  return true;
+}
+
 let activeParser = null;
 
 function detectParser() {
@@ -533,6 +545,7 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
           const options = {
             highQuality: request.highQualityPng !== false,
             theme: request.theme,
+            includeAttribution: await getAttributionSetting(),
           };
           const formattedResult = await formatter.format(conversation, options);
           const mimeType = formatter.getMimeType();
@@ -625,7 +638,10 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
             });
           }
           console.log('Parsed conversation with', conversation.messages.length, 'messages');
-          const formatOptions = request.theme ? { theme: request.theme } : {};
+          const formatOptions = {
+            theme: request.theme,
+            includeAttribution: await getAttributionSetting(),
+          };
           const primaryContent = formatter.format(conversation, formatOptions);
           const htmlFormatter = formatters.html;
           const richHtmlContent = htmlFormatter
@@ -718,7 +734,9 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
           }
 
           const formatter = formatters.markdown;
-          const markdownContent = formatter.format(conversation);
+          const markdownContent = formatter.format(conversation, {
+            includeAttribution: await getAttributionSetting(),
+          });
 
           if (shortcut === 'copy_markdown') {
             const copied = await copyToClipboard(markdownContent);

--- a/content/main.js
+++ b/content/main.js
@@ -32,6 +32,7 @@ import {
   DEFAULT_FILENAME_TEMPLATE,
 } from './utils/filename.js';
 import { createLogger } from './utils/logger.js';
+import { getAttributionSetting } from './utils/preferences.js';
 
 const logger = createLogger('ContentScript');
 
@@ -174,18 +175,6 @@ function stripImages(content) {
   cleaned = cleaned.replace(/\n{3,}/g, '\n\n').trim();
 
   return cleaned;
-}
-
-async function getAttributionSetting() {
-  try {
-    const syncData = await chrome.storage.sync.get('includeAttribution');
-    if (syncData && syncData.includeAttribution !== undefined) {
-      return syncData.includeAttribution;
-    }
-  } catch {
-    // Ignore storage errors and fall back to the default
-  }
-  return true;
 }
 
 let activeParser = null;

--- a/content/utils/preferences.js
+++ b/content/utils/preferences.js
@@ -1,0 +1,13 @@
+export const DEFAULT_INCLUDE_ATTRIBUTION = true;
+
+export async function getAttributionSetting() {
+  try {
+    const syncData = await chrome.storage.sync.get('includeAttribution');
+    if (syncData && syncData.includeAttribution !== undefined) {
+      return syncData.includeAttribution;
+    }
+  } catch {
+    // Ignore storage errors and fall back to the default
+  }
+  return DEFAULT_INCLUDE_ATTRIBUTION;
+}

--- a/entrypoints/content.js
+++ b/entrypoints/content.js
@@ -155,6 +155,18 @@ export default defineContentScript({
 
     let activeParser = null;
 
+    async function getAttributionSetting() {
+      try {
+        const syncData = await chrome.storage.sync.get('includeAttribution');
+        if (syncData && syncData.includeAttribution !== undefined) {
+          return syncData.includeAttribution;
+        }
+      } catch {
+        // Ignore storage errors and fall back to the default
+      }
+      return true;
+    }
+
     function detectParser() {
       const currentUrl = window.location.href;
       logger.debug('Detecting parser for URL:', currentUrl);
@@ -517,6 +529,7 @@ export default defineContentScript({
               const options = {
                 highQuality: request.highQualityPng !== false,
                 theme: request.theme,
+                includeAttribution: await getAttributionSetting(),
               };
               const formattedResult = await formatter.format(conversation, options);
               const mimeType = formatter.getMimeType();
@@ -617,7 +630,10 @@ export default defineContentScript({
                 });
               }
               logger.debug('Parsed conversation with', conversation.messages.length, 'messages');
-              const formatOptions = request.theme ? { theme: request.theme } : {};
+              const formatOptions = {
+                theme: request.theme,
+                includeAttribution: await getAttributionSetting(),
+              };
               const primaryContent = formatter.format(conversation, formatOptions);
               const htmlFormatter = formatters.html;
               const richHtmlContent = htmlFormatter
@@ -724,7 +740,9 @@ export default defineContentScript({
               }
 
               const formatter = formatters.markdown;
-              const markdownContent = formatter.format(conversation);
+              const markdownContent = formatter.format(conversation, {
+                includeAttribution: await getAttributionSetting(),
+              });
 
               if (shortcut === 'copy_markdown') {
                 const copied = await copyToClipboard(markdownContent);

--- a/entrypoints/content.js
+++ b/entrypoints/content.js
@@ -32,6 +32,7 @@ import {
 } from '../content/utils/filename.js';
 import { stripImages } from '../content/utils/strip-images.js';
 import { createLogger } from '../content/utils/logger.js';
+import { getAttributionSetting } from '../content/utils/preferences.js';
 
 const logger = createLogger('ContentScript');
 
@@ -154,18 +155,6 @@ export default defineContentScript({
     }
 
     let activeParser = null;
-
-    async function getAttributionSetting() {
-      try {
-        const syncData = await chrome.storage.sync.get('includeAttribution');
-        if (syncData && syncData.includeAttribution !== undefined) {
-          return syncData.includeAttribution;
-        }
-      } catch {
-        // Ignore storage errors and fall back to the default
-      }
-      return true;
-    }
 
     function detectParser() {
       const currentUrl = window.location.href;

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -143,6 +143,15 @@
               </label>
             </div>
 
+            <div class="field-group checkbox-group">
+              <label class="checkbox-label">
+                <input type="checkbox" id="include-attribution" checked />
+                <span data-i18n="includeAttributionDefault"
+                  >Include "Exported with AI Chat Exporter" credit in exports</span
+                >
+              </label>
+            </div>
+
             <div class="field-group" style="margin-top: 12px">
               <label
                 for="filename-template-input"

--- a/entrypoints/options/options.js
+++ b/entrypoints/options/options.js
@@ -34,6 +34,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const languageSelect = document.getElementById('language-select');
   const defaultFormatSelect = document.getElementById('default-format-select');
   const defaultIncludeImages = document.getElementById('default-include-images');
+  const includeAttribution = document.getElementById('include-attribution');
   const filenameTemplateInput = document.getElementById('filename-template-input');
   const filenamePreview = document.getElementById('filename-preview');
   const parserModeSelect = document.getElementById('parser-mode-select');
@@ -79,6 +80,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     'uiLanguage',
     'defaultFormat',
     'includeImages',
+    'includeAttribution',
     'filenameTemplate',
     'parserMode',
     'defaultTransferTarget',
@@ -103,6 +105,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (stored.defaultFormat) defaultFormatSelect.value = stored.defaultFormat;
   if (stored.includeImages !== undefined) defaultIncludeImages.checked = stored.includeImages;
+  if (stored.includeAttribution !== undefined)
+    includeAttribution.checked = stored.includeAttribution;
   if (filenameTemplateInput) {
     filenameTemplateInput.value = stored.filenameTemplate || DEFAULT_FILENAME_TEMPLATE;
     updateFilenamePreview(filenameTemplateInput.value);
@@ -142,6 +146,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   defaultIncludeImages.addEventListener('change', () => {
     chrome.storage.sync.set({ includeImages: defaultIncludeImages.checked });
+    showToast();
+  });
+
+  includeAttribution.addEventListener('change', () => {
+    chrome.storage.sync.set({ includeAttribution: includeAttribution.checked });
     showToast();
   });
 

--- a/entrypoints/preview/preview.js
+++ b/entrypoints/preview/preview.js
@@ -93,9 +93,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   const transferTargetSelect = document.getElementById('transfer-target-select');
 
   let currentSyncTheme = 'system';
+  let includeAttribution = true;
   try {
-    const syncData = await chrome.storage.sync.get('theme');
+    const syncData = await chrome.storage.sync.get(['theme', 'includeAttribution']);
     currentSyncTheme = syncData.theme || 'system';
+    if (syncData.includeAttribution !== undefined) {
+      includeAttribution = syncData.includeAttribution;
+    }
     applyTheme(currentSyncTheme, document);
   } catch {
     // Ignore theme loading errors when running standalone
@@ -440,10 +444,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     htmlContent = htmlFormatter.format(activeConv, {
       theme: currentSyncTheme,
       includeToc: shouldIncludeToc,
+      includeAttribution,
     });
-    markdownContent = markdownFormatter.format(activeConv);
+    markdownContent = markdownFormatter.format(activeConv, { includeAttribution });
     jsonContent = jsonFormatter.format(activeConv);
-    docContent = docFormatter.format(activeConv);
+    docContent = docFormatter.format(activeConv, { includeAttribution });
 
     cachedPngBlob = null;
     switchTab(currentActiveTab);
@@ -828,10 +833,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         return msg;
       });
       const initialConv = { ...conversation, messages: initialMessages };
-      htmlContent = htmlFormatter.format(initialConv, { theme: currentSyncTheme });
-      markdownContent = markdownFormatter.format(initialConv);
+      htmlContent = htmlFormatter.format(initialConv, {
+        theme: currentSyncTheme,
+        includeAttribution,
+      });
+      markdownContent = markdownFormatter.format(initialConv, { includeAttribution });
       jsonContent = jsonFormatter.format(initialConv);
-      docContent = docFormatter.format(initialConv);
+      docContent = docFormatter.format(initialConv, { includeAttribution });
     } else {
       const fallbackContent = data.previewContent || '';
       htmlContent = sanitizeHtml(fallbackContent);
@@ -1024,6 +1032,7 @@ document.addEventListener('DOMContentLoaded', async () => {
               highQuality: isHighQuality,
               includeImages,
               theme: activeTheme,
+              includeAttribution,
             });
           }
           cachedPngBlob = pngBlob;

--- a/options/options.html
+++ b/options/options.html
@@ -143,6 +143,15 @@
               </label>
             </div>
 
+            <div class="field-group checkbox-group">
+              <label class="checkbox-label">
+                <input type="checkbox" id="include-attribution" checked />
+                <span data-i18n="includeAttributionDefault"
+                  >Include "Exported with AI Chat Exporter" credit in exports</span
+                >
+              </label>
+            </div>
+
             <div class="field-group" style="margin-top: 12px">
               <label
                 for="filename-template-input"

--- a/options/options.js
+++ b/options/options.js
@@ -34,6 +34,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const languageSelect = document.getElementById('language-select');
   const defaultFormatSelect = document.getElementById('default-format-select');
   const defaultIncludeImages = document.getElementById('default-include-images');
+  const includeAttribution = document.getElementById('include-attribution');
   const filenameTemplateInput = document.getElementById('filename-template-input');
   const filenamePreview = document.getElementById('filename-preview');
   const parserModeSelect = document.getElementById('parser-mode-select');
@@ -79,6 +80,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     'uiLanguage',
     'defaultFormat',
     'includeImages',
+    'includeAttribution',
     'filenameTemplate',
     'parserMode',
     'defaultTransferTarget',
@@ -103,6 +105,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (stored.defaultFormat) defaultFormatSelect.value = stored.defaultFormat;
   if (stored.includeImages !== undefined) defaultIncludeImages.checked = stored.includeImages;
+  if (stored.includeAttribution !== undefined)
+    includeAttribution.checked = stored.includeAttribution;
   if (filenameTemplateInput) {
     filenameTemplateInput.value = stored.filenameTemplate || DEFAULT_FILENAME_TEMPLATE;
     updateFilenamePreview(filenameTemplateInput.value);
@@ -142,6 +146,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   defaultIncludeImages.addEventListener('change', () => {
     chrome.storage.sync.set({ includeImages: defaultIncludeImages.checked });
+    showToast();
+  });
+
+  includeAttribution.addEventListener('change', () => {
+    chrome.storage.sync.set({ includeAttribution: includeAttribution.checked });
     showToast();
   });
 

--- a/popup/preview.js
+++ b/popup/preview.js
@@ -64,9 +64,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Load and apply extension theme
   let currentSyncTheme = 'system';
+  let includeAttribution = true;
   try {
-    const syncData = await chrome.storage.sync.get('theme');
+    const syncData = await chrome.storage.sync.get(['theme', 'includeAttribution']);
     currentSyncTheme = syncData.theme || 'system';
+    if (syncData.includeAttribution !== undefined) {
+      includeAttribution = syncData.includeAttribution;
+    }
     applyTheme(currentSyncTheme, document);
   } catch {
     // Ignore theme loading errors when running standalone
@@ -421,10 +425,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     titleEl.textContent = title;
 
     if (conversation) {
-      htmlContent = htmlFormatter.format(conversation);
-      markdownContent = markdownFormatter.format(conversation);
+      htmlContent = htmlFormatter.format(conversation, { includeAttribution });
+      markdownContent = markdownFormatter.format(conversation, { includeAttribution });
       jsonContent = jsonFormatter.format(conversation);
-      docContent = docFormatter.format(conversation);
+      docContent = docFormatter.format(conversation, { includeAttribution });
     } else {
       const fallbackContent = data.previewContent || '';
       htmlContent = sanitizeHtml(fallbackContent);
@@ -593,6 +597,7 @@ document.addEventListener('DOMContentLoaded', async () => {
               highQuality: isHighQuality,
               includeImages,
               theme: activeTheme,
+              includeAttribution,
             });
           }
           cachedPngBlob = pngBlob;

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -227,6 +227,10 @@
     "message": "Bilder standardmäßig in Exporte einschließen",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Hinweis \"Exported with AI Chat Exporter\" in Exporten einschließen",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Parser-Extraktionsmodus",
     "description": "Title for parser mode section"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -227,6 +227,10 @@
     "message": "Include images in exports by default",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Include \"Exported with AI Chat Exporter\" credit in exports",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Parser Extraction Mode",
     "description": "Title for parser mode section"

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -227,6 +227,10 @@
     "message": "Incluir imágenes en las exportaciones por defecto",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Incluir el crédito \"Exported with AI Chat Exporter\" en las exportaciones",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Modo de extracción del analizador",
     "description": "Title for parser mode section"

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -227,6 +227,10 @@
     "message": "Inclure les images dans les exports par défaut",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Inclure la mention \"Exported with AI Chat Exporter\" dans les exports",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Mode d'extraction de l'analyseur",
     "description": "Title for parser mode section"

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -227,6 +227,10 @@
     "message": "डिफ़ॉल्ट रूप से निर्यात में छवियां शामिल करें",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "निर्यात में \"Exported with AI Chat Exporter\" क्रेडिट शामिल करें",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "पार्सर निष्कर्षण मोड",
     "description": "Title for parser mode section"

--- a/public/_locales/it/messages.json
+++ b/public/_locales/it/messages.json
@@ -227,6 +227,10 @@
     "message": "Includi immagini nelle esportazioni per impostazione predefinita",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Includi la dicitura \"Exported with AI Chat Exporter\" nelle esportazioni",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Modalità di estrazione del parser",
     "description": "Title for parser mode section"

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -227,6 +227,10 @@
     "message": "既定でエクスポートに画像を含める",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "エクスポートに「Exported with AI Chat Exporter」のクレジットを含める",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "パーサー抽出モード",
     "description": "Title for parser mode section"

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -227,6 +227,10 @@
     "message": "내보낼 때 기본적으로 이미지 포함",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "내보내기에 \"Exported with AI Chat Exporter\" 크레딧 포함",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "파서 추출 모드",
     "description": "Title for parser mode section"

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -227,6 +227,10 @@
     "message": "Incluir imagens nas exportações por padrão",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Incluir o crédito \"Exported with AI Chat Exporter\" nas exportações",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Modo de extração do analisador",
     "description": "Title for parser mode section"

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -228,7 +228,7 @@
     "description": "Label for default include images checkbox"
   },
   "includeAttributionDefault": {
-    "message": "Включать упоминание \"Exported with AI Chat Exporter\" в экспорт",
+    "message": "Включать упоминание \"Exported with AI Chat Exporter\" при экспорте",
     "description": "Label for default include attribution credit checkbox"
   },
   "parserModeTitle": {

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -227,6 +227,10 @@
     "message": "Включать изображения в экспорт по умолчанию",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "Включать упоминание \"Exported with AI Chat Exporter\" в экспорт",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "Режим извлечения парсера",
     "description": "Title for parser mode section"

--- a/public/_locales/ta/messages.json
+++ b/public/_locales/ta/messages.json
@@ -227,6 +227,10 @@
     "message": "இயல்புநிலையாக ஏற்றுமதியில் படங்களைச் சேர்க்கவும்",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "ஏற்றுமதிகளில் \"Exported with AI Chat Exporter\" குறிப்பைச் சேர்க்கவும்",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "பிரித்தெடுத்தல் முறைமை (Parser Mode)",
     "description": "Title for parser mode section"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -227,6 +227,10 @@
     "message": "默认在导出的内容中包含图片",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "在导出中包含 \"Exported with AI Chat Exporter\" 署名",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "解析器提取模式",
     "description": "Title for parser mode section"

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -227,6 +227,10 @@
     "message": "預設在匯出內容中包含圖片",
     "description": "Label for default include images checkbox"
   },
+  "includeAttributionDefault": {
+    "message": "在匯出中包含 \"Exported with AI Chat Exporter\" 署名",
+    "description": "Label for default include attribution credit checkbox"
+  },
   "parserModeTitle": {
     "message": "解析器擷取模式",
     "description": "Title for parser mode section"

--- a/tests/doc-formatter.test.mjs
+++ b/tests/doc-formatter.test.mjs
@@ -46,6 +46,24 @@ test('DocFormatter returns correct file extension (.doc) and MIME type (applicat
   assert.equal(formatter.getMimeType(), 'application/msword');
 });
 
+test('DocFormatter omits AI Chat Exporter credit when includeAttribution is false', async () => {
+  const { DocFormatter } = await importFormatter();
+  const formatter = new DocFormatter();
+
+  const conversation = {
+    title: 'No Credit Test',
+    messages: [{ role: 'User', content: 'Hello' }],
+    metadata: { Source: 'Claude' },
+  };
+
+  const withCredit = formatter.format(conversation);
+  assert.ok(withCredit.includes('ai-chat-exporter.covai.org'));
+
+  const withoutCredit = formatter.format(conversation, { includeAttribution: false });
+  assert.ok(!withoutCredit.includes('ai-chat-exporter.covai.org'));
+  assert.ok(withoutCredit.includes('Exported from Claude'));
+});
+
 test('DocFormatter generates Word-compliant HTML document with MSO XML headers', async () => {
   const { DocFormatter } = await importFormatter();
   const formatter = new DocFormatter();

--- a/tests/doc-formatter.test.mjs
+++ b/tests/doc-formatter.test.mjs
@@ -57,10 +57,10 @@ test('DocFormatter omits AI Chat Exporter credit when includeAttribution is fals
   };
 
   const withCredit = formatter.format(conversation);
-  assert.ok(withCredit.includes('ai-chat-exporter.covai.org'));
+  assert.ok(withCredit.includes('https://ai-chat-exporter.covai.org'));
 
   const withoutCredit = formatter.format(conversation, { includeAttribution: false });
-  assert.ok(!withoutCredit.includes('ai-chat-exporter.covai.org'));
+  assert.ok(!withoutCredit.includes('https://ai-chat-exporter.covai.org'));
   assert.ok(withoutCredit.includes('Exported from Claude'));
 });
 

--- a/tests/html-formatter.test.mjs
+++ b/tests/html-formatter.test.mjs
@@ -187,6 +187,25 @@ test('HTML formatter renders task list checkboxes, collapsible thinking blocks, 
   );
 });
 
+test('HTML formatter omits export footer when includeAttribution is false', async () => {
+  const { HtmlFormatter } = await importFormatter();
+  const formatter = new HtmlFormatter();
+
+  const conversation = {
+    title: 'No Footer Test',
+    messages: [{ role: 'User', content: 'Hello' }],
+    metadata: { Source: 'Claude' },
+  };
+
+  const withFooter = formatter.format(conversation);
+  assert.ok(withFooter.includes('<footer class="export-footer">'));
+
+  const withoutFooter = formatter.format(conversation, { includeAttribution: false });
+  assert.ok(!withoutFooter.includes('<footer class="export-footer">'));
+  assert.ok(!withoutFooter.includes('href="https://ai-chat-exporter.covai.org/"'));
+  assert.ok(withoutFooter.includes('<title>No Footer Test</title>'));
+});
+
 test('HTML formatter formats LaTeX math equations with bracket and dollar delimiters', async () => {
   const { HtmlFormatter } = await importFormatter();
   const formatter = new HtmlFormatter();

--- a/tests/image-formatter.test.mjs
+++ b/tests/image-formatter.test.mjs
@@ -110,7 +110,7 @@ test('ImageFormatter.createScreenshotContainer omits footer watermark when inclu
   const html = container.innerHTML;
   assert.ok(!html.includes('Exported with'));
   assert.ok(!html.includes('AI Chat Exporter'));
-  assert.ok(!html.includes('ai-chat-exporter.covai.org'));
+  assert.ok(!html.includes('https://ai-chat-exporter.covai.org'));
 });
 
 test('ImageFormatter.preloadImages sanitizes cross-origin images to prevent canvas taint', async () => {

--- a/tests/image-formatter.test.mjs
+++ b/tests/image-formatter.test.mjs
@@ -87,6 +87,32 @@ test('ImageFormatter creates styled screenshot container with conversation conte
   assert.ok(html.includes('.code-card'));
 });
 
+test('ImageFormatter.createScreenshotContainer omits footer watermark when includeAttribution is false', async () => {
+  const { ImageFormatter } = await importFormatter();
+  const formatter = new ImageFormatter();
+
+  if (typeof globalThis.document === 'undefined') {
+    const { document, window } = parseHTML('<!DOCTYPE html><html><body></body></html>');
+    globalThis.document = document;
+    globalThis.window = window;
+  }
+
+  const conversation = {
+    title: 'No Watermark Test',
+    messages: [{ role: 'User', content: 'Hello AI!' }],
+    metadata: { Source: 'ChatGPT' },
+  };
+
+  const container = formatter.createScreenshotContainer(conversation, {
+    includeAttribution: false,
+  });
+
+  const html = container.innerHTML;
+  assert.ok(!html.includes('Exported with'));
+  assert.ok(!html.includes('AI Chat Exporter'));
+  assert.ok(!html.includes('ai-chat-exporter.covai.org'));
+});
+
 test('ImageFormatter.preloadImages sanitizes cross-origin images to prevent canvas taint', async () => {
   const { ImageFormatter } = await importFormatter();
   const formatter = new ImageFormatter();

--- a/tests/markdown-formatter.test.mjs
+++ b/tests/markdown-formatter.test.mjs
@@ -33,6 +33,25 @@ test('MarkdownFormatter includes top site link, platform source, hyperlinked URL
   assert.ok(output.includes('**Method:** API'));
 });
 
+test('MarkdownFormatter omits Exported with credit when includeAttribution is false', () => {
+  const formatter = new MarkdownFormatter();
+
+  const conversation = {
+    title: 'No Credit Test',
+    messages: [{ role: 'User', content: 'Hello' }],
+    metadata: {
+      Source: 'Claude',
+      Date: '8/6/2026 12:00:00',
+    },
+  };
+
+  const output = formatter.format(conversation, { includeAttribution: false });
+
+  assert.ok(!output.includes('**Exported with:**'));
+  assert.ok(output.includes('**Source:** Claude'));
+  assert.ok(output.includes('**Date:** 8/6/2026 12:00:00'));
+});
+
 test('MarkdownFormatter omits Model and Link when missing', () => {
   const formatter = new MarkdownFormatter();
 


### PR DESCRIPTION
Add an "Include 'Exported with AI Chat Exporter' credit in exports" preference so users exporting into professional documents can omit the branding. Defaults to on, and every gate tests `!== false` so any call site that forgets the option still renders the credit.

- Add the includeAttribution setting to both options pages, with i18n strings for all 13 locales in both _locales trees
- Gate attribution in the markdown, html, image, and doc formatters
- Read the preference in both content scripts and both preview pages so previews, and downloads started from a preview, match the real export

The html and image formatters each emit attribution twice, once in the header metadata and once in the footer, so both references are gated. DocFormatter.format() accepted no options argument, so the preference the content script export path passed to it needed plumbing through.

Add gating tests for all four formatters. The image formatter assertion matches on the bare domain rather than the footer's trailing-slash URL, so it covers the header credit as well as the footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an export preference to include or omit the “Exported with AI Chat Exporter” attribution.
  * Attribution is included by default across HTML, Markdown, DOC, PNG and copy exports.
  * Added the setting to export previews and options pages.
* **Localisation**
  * Added translations for the attribution setting across supported languages.
* **Bug Fixes**
  * Export previews and generated files now consistently respect the saved attribution preference.
  * Preview format tabs now correctly follow the selected export format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->