### PR TITLE
feat: progressive detection, parse caching, reparse control, and preview enhancements

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -11,6 +11,32 @@
     "message": "Erkenne Chat...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Verbinde...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Nachrichten werden gescannt...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Chat neu einlesen",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$-Chat bereit zum Exportieren ($COUNT$ Nachrichten)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Bereit",
     "description": "Status shown when chat is detected"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -414,11 +414,19 @@
     "description": "Title of message selector drawer"
   },
   "selectAll": {
-    "message": "Select All",
+    "message": "All",
     "description": "Select all button in turn selector"
   },
+  "selectPrompts": {
+    "message": "Prompts",
+    "description": "Select only user prompt turns"
+  },
+  "selectResponses": {
+    "message": "Responses",
+    "description": "Select only assistant response turns"
+  },
   "deselectAll": {
-    "message": "Deselect All",
+    "message": "None",
     "description": "Deselect all button in turn selector"
   },
   "done": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -11,6 +11,32 @@
     "message": "Detecting...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Connecting...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Scanning messages...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Reparse Chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ chat ready to export ($COUNT$ messages)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Ready",
     "description": "Status shown when chat is detected"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -11,6 +11,32 @@
     "message": "Detectando...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Conectando...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Escaneando mensajes...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Volver a analizar chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Chat de $PLATFORM$ listo para exportar ($COUNT$ mensajes)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Listo",
     "description": "Status shown when chat is detected"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -11,6 +11,32 @@
     "message": "Détection en cours...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Connexion...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Analyse des messages...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Réanalyser le chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Chat $PLATFORM$ prêt à exporter ($COUNT$ messages)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Prêt",
     "description": "Status shown when chat is detected"

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -11,6 +11,32 @@
     "message": "पहचान जारी है...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "कनेक्ट हो रहा है...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "संदेश स्कैन किए जा रहे हैं...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "चैट पुन: पार्स करें",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ चैट निर्यात के लिए तैयार ($COUNT$ संदेश)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "तैयार",
     "description": "Status shown when chat is detected"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -11,6 +11,32 @@
     "message": "Rilevamento in corso...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Connessione in corso...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Scansione messaggi in corso...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Rianalizza chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Chat $PLATFORM$ pronta per l'esportazione ($COUNT$ messaggi)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Pronto",
     "description": "Status shown when chat is detected"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -11,6 +11,32 @@
     "message": "検出中...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "接続中...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "メッセージをスキャン中...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "チャットを再解析",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ チャットのエクスポート準備完了 ($COUNT$ 件のメッセージ)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "準備完了",
     "description": "Status shown when chat is detected"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -11,6 +11,32 @@
     "message": "대화 감지 중...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "연결 중...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "메시지 검사 중...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "채팅 다시 파싱",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ 채팅 내보내기 준비 완료 ($COUNT$개 메시지)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "준비 완료",
     "description": "Status shown when chat is detected"

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -11,6 +11,32 @@
     "message": "Detectando...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Conectando...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Examinando mensagens...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Reprocessar chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Chat do $PLATFORM$ pronto para exportar ($COUNT$ mensagens)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Pronto",
     "description": "Status shown when chat is detected"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -11,6 +11,32 @@
     "message": "Поиск чата...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Подключение...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Сканирование сообщений...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Переанализировать чат",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Чат $PLATFORM$ готов к экспорту ($COUNT$ сообщений)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Готово",
     "description": "Status shown when chat is detected"

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -11,6 +11,32 @@
     "message": "கண்டறிகிறது...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "இணைக்கப்படுகிறது...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "செய்திகள் ஸ்கேன் செய்யப்படுகின்றன...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "அரட்டையை மீண்டும் பாகுபடுத்து",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ அரட்டை ஏற்றுமதிக்கு தயார் ($COUNT$ செய்திகள்)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "தயார்",
     "description": "Status shown when chat is detected"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -11,6 +11,32 @@
     "message": "正在检测...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "连接中...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "正在扫描消息...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "重新解析对话",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ 对话已准备好导出（$COUNT$ 条消息）",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "就绪",
     "description": "Status shown when chat is detected"

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -11,6 +11,32 @@
     "message": "正在偵測...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "連線中...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "正在掃描訊息...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "重新解析對話",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ 對話已準備好匯出（$COUNT$ 則訊息）",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "就緒",
     "description": "Status shown when chat is detected"

--- a/content/main.js
+++ b/content/main.js
@@ -236,38 +236,53 @@ function setupDomObserver() {
   }
   if (domObserver) return;
 
+  function isToastNode(node) {
+    if (!node) return false;
+    if (node.nodeType === 1) {
+      return (
+        node.id === 'ai-chat-exporter-toast' || Boolean(node.closest?.('#ai-chat-exporter-toast'))
+      );
+    }
+    return Boolean(node.parentElement?.closest?.('#ai-chat-exporter-toast'));
+  }
+
   domObserver = new MutationObserver((mutations) => {
-    let hasAddedNodes = false;
+    let hasRelevantMutation = false;
     for (const m of mutations) {
-      if (m.addedNodes && m.addedNodes.length > 0) {
-        for (let i = 0; i < m.addedNodes.length; i++) {
-          const node = m.addedNodes[i];
-          if (
-            node.nodeType === 1 &&
-            node.id !== 'ai-chat-exporter-toast' &&
-            !node.closest?.('#ai-chat-exporter-toast')
-          ) {
-            hasAddedNodes = true;
+      if (m.type === 'characterData') {
+        if (!isToastNode(m.target)) {
+          hasRelevantMutation = true;
+          break;
+        }
+      } else if (m.type === 'childList') {
+        const nodes = [...(m.addedNodes || []), ...(m.removedNodes || [])];
+        for (const node of nodes) {
+          if (!isToastNode(node)) {
+            hasRelevantMutation = true;
             break;
           }
         }
-        if (hasAddedNodes) break;
+        if (hasRelevantMutation) break;
       }
     }
 
-    if (hasAddedNodes) {
+    if (hasRelevantMutation) {
+      if (parseCache) {
+        parseCache.dirty = true;
+      }
       clearTimeout(mutationDebounceTimer);
       mutationDebounceTimer = setTimeout(() => {
-        if (parseCache) {
-          logger.debug('Chat DOM mutation detected, marking parse cache dirty');
-          parseCache.dirty = true;
-        }
+        logger.debug('Chat DOM mutation detected and debounced');
       }, 600);
     }
   });
 
   try {
-    domObserver.observe(document.body, { childList: true, subtree: true });
+    domObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
   } catch (e) {
     logger.debug('DOM MutationObserver registration failed:', e);
   }
@@ -355,7 +370,10 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
 
             const elapsed = Date.now() - startTime;
             if (!isPopupOpen && currentFrameIsTop && count > 0 && elapsed > 250) {
-              showExporterToast(`⚡ ${platformName} chat ready to export (${count} messages)`);
+              const toastMsg =
+                chrome.i18n?.getMessage('toastChatReady', [platformName, String(count)]) ||
+                `⚡ ${platformName} chat ready to export (${count} messages)`;
+              showExporterToast(toastMsg);
             }
           } catch (e) {
             logger.error('Discover frames parse error:', e);
@@ -450,7 +468,10 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
 
             const elapsed = Date.now() - startTime;
             if (!isPopupOpen && currentFrameIsTop && count > 0 && elapsed > 250) {
-              showExporterToast(`⚡ ${platformName} chat ready to export (${count} messages)`);
+              const toastMsg =
+                chrome.i18n?.getMessage('toastChatReady', [platformName, String(count)]) ||
+                `⚡ ${platformName} chat ready to export (${count} messages)`;
+              showExporterToast(toastMsg);
             }
           } catch (e) {
             logger.error('Check availability parse threw error:', e);

--- a/content/main.js
+++ b/content/main.js
@@ -199,6 +199,80 @@ function detectParser() {
   }
 }
 
+const PARSE_CACHE_TTL_MS = 90 * 1000;
+let parseCache = null;
+let isPopupOpen = false;
+let domObserver = null;
+let mutationDebounceTimer = null;
+
+if (typeof chrome !== 'undefined' && chrome.runtime?.onConnect) {
+  chrome.runtime.onConnect.addListener((port) => {
+    if (port && port.name === 'popup-tab-session') {
+      isPopupOpen = true;
+      port.onDisconnect.addListener(() => {
+        isPopupOpen = false;
+      });
+    }
+  });
+}
+
+function isCacheValid(requestedMode) {
+  if (!parseCache || parseCache.dirty || !parseCache.report) return false;
+  if (parseCache.url !== window.location.href) return false;
+  if (requestedMode && parseCache.parserMode && parseCache.parserMode !== requestedMode) {
+    return false;
+  }
+  const age = Date.now() - parseCache.timestamp;
+  return age < PARSE_CACHE_TTL_MS;
+}
+
+function setupDomObserver() {
+  if (
+    typeof MutationObserver === 'undefined' ||
+    typeof document === 'undefined' ||
+    !document.body
+  ) {
+    return;
+  }
+  if (domObserver) return;
+
+  domObserver = new MutationObserver((mutations) => {
+    let hasAddedNodes = false;
+    for (const m of mutations) {
+      if (m.addedNodes && m.addedNodes.length > 0) {
+        for (let i = 0; i < m.addedNodes.length; i++) {
+          const node = m.addedNodes[i];
+          if (
+            node.nodeType === 1 &&
+            node.id !== 'ai-chat-exporter-toast' &&
+            !node.closest?.('#ai-chat-exporter-toast')
+          ) {
+            hasAddedNodes = true;
+            break;
+          }
+        }
+        if (hasAddedNodes) break;
+      }
+    }
+
+    if (hasAddedNodes) {
+      clearTimeout(mutationDebounceTimer);
+      mutationDebounceTimer = setTimeout(() => {
+        if (parseCache) {
+          logger.debug('Chat DOM mutation detected, marking parse cache dirty');
+          parseCache.dirty = true;
+        }
+      }, 600);
+    }
+  });
+
+  try {
+    domObserver.observe(document.body, { childList: true, subtree: true });
+  } catch (e) {
+    logger.debug('DOM MutationObserver registration failed:', e);
+  }
+}
+
 // Listen for messages from the popup
 if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -207,13 +281,42 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
       `Message received: action=${request.action} on frame=${currentFrameIsTop ? 'TOP' : 'IFRAME'}`,
     );
 
+    if (request.action === 'CLEAR_CACHE') {
+      parseCache = null;
+      sendResponse({ success: true });
+      return true;
+    }
+
+    if (request.action === 'SHOW_TOAST') {
+      showExporterToast(request.message, request.toastType || 'success');
+      sendResponse({ success: true });
+      return true;
+    }
+
     if (request.action === 'DISCOVER_FRAMES') {
       detectParser();
+      setupDomObserver();
       const queryId = request.queryId;
+      const isForce = Boolean(request.force);
+      const parserMode = request.parserMode || 'auto';
+
       if (activeParser) {
         (async () => {
           try {
-            const conversation = enrichConversation(await activeParser.parse({ full: false }));
+            if (!isForce && isCacheValid(parserMode)) {
+              logger.debug('DISCOVER_FRAMES returning cached report');
+              chrome.runtime.sendMessage({
+                action: 'FRAME_REPORT',
+                queryId,
+                data: parseCache.report,
+              });
+              return;
+            }
+
+            const startTime = Date.now();
+            const conversation = enrichConversation(
+              await activeParser.parse({ full: false, parserMode }),
+            );
             const count = conversation?.messages?.length || 0;
             if (!currentFrameIsTop && count === 0) {
               return;
@@ -226,18 +329,34 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
                 ? activeParser.getPlatformName()
                 : activeParser.name || activeParser.constructor.name.replace('Parser', '');
 
+            const reportData = {
+              available: true,
+              platform: platformName,
+              isDedicatedAi,
+              count,
+              title: conversation?.title || '',
+              isTopFrame: currentFrameIsTop,
+            };
+
+            parseCache = {
+              url: window.location.href,
+              timestamp: Date.now(),
+              parserMode,
+              report: reportData,
+              conversation,
+              dirty: false,
+            };
+
             chrome.runtime.sendMessage({
               action: 'FRAME_REPORT',
               queryId,
-              data: {
-                available: true,
-                platform: platformName,
-                isDedicatedAi,
-                count,
-                title: conversation?.title || '',
-                isTopFrame: currentFrameIsTop,
-              },
+              data: reportData,
             });
+
+            const elapsed = Date.now() - startTime;
+            if (!isPopupOpen && currentFrameIsTop && count > 0 && elapsed > 250) {
+              showExporterToast(`⚡ ${platformName} chat ready to export (${count} messages)`);
+            }
           } catch (e) {
             logger.error('Discover frames parse error:', e);
             if (currentFrameIsTop) {
@@ -276,15 +395,29 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
 
     if (request.action === 'CHECK_AVAILABILITY') {
       detectParser();
+      setupDomObserver();
+      const isForce = Boolean(request.force);
+      const parserMode = request.parserMode || 'auto';
+
       if (activeParser) {
         (async () => {
           try {
-            logger.debug('Executing activeParser.parse({ full: false })...');
-            const conversation = enrichConversation(await activeParser.parse({ full: false }));
-            logger.debug(
-              `Availability check parsed ${conversation.messages.length} messages, title: "${conversation.title || ''}"`,
+            if (!isForce && isCacheValid(parserMode)) {
+              logger.debug('CHECK_AVAILABILITY returning cached report');
+              sendResponse(parseCache.report);
+              return;
+            }
+
+            const startTime = Date.now();
+            logger.debug('Executing activeParser.parse({ full: false, parserMode })...');
+            const conversation = enrichConversation(
+              await activeParser.parse({ full: false, parserMode }),
             );
-            if (!currentFrameIsTop && conversation.messages.length === 0) {
+            const count = conversation?.messages?.length || 0;
+            logger.debug(
+              `Availability check parsed ${count} messages, title: "${conversation?.title || ''}"`,
+            );
+            if (!currentFrameIsTop && count === 0) {
               logger.debug('Subframe has 0 messages, ignoring subframe response');
               return;
             }
@@ -295,11 +428,30 @@ if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
             const responseData = {
               available: true,
               platform: platformName,
-              count: conversation.messages.length,
-              title: conversation.title || '',
+              count,
+              title: conversation?.title || '',
+              isDedicatedAi:
+                activeParser.name !== 'WebArticle' &&
+                activeParser.constructor?.name !== 'ArticleParser',
+              isTopFrame: currentFrameIsTop,
             };
+
+            parseCache = {
+              url: window.location.href,
+              timestamp: Date.now(),
+              parserMode,
+              report: responseData,
+              conversation,
+              dirty: false,
+            };
+
             logger.debug('Sending CHECK_AVAILABILITY response:', responseData);
             sendResponse(responseData);
+
+            const elapsed = Date.now() - startTime;
+            if (!isPopupOpen && currentFrameIsTop && count > 0 && elapsed > 250) {
+              showExporterToast(`⚡ ${platformName} chat ready to export (${count} messages)`);
+            }
           } catch (e) {
             logger.error('Check availability parse threw error:', e);
             if (currentFrameIsTop) {

--- a/entrypoints/content.js
+++ b/entrypoints/content.js
@@ -213,38 +213,54 @@ export default defineContentScript({
       }
       if (domObserver) return;
 
+      function isToastNode(node) {
+        if (!node) return false;
+        if (node.nodeType === 1) {
+          return (
+            node.id === 'ai-chat-exporter-toast' ||
+            Boolean(node.closest?.('#ai-chat-exporter-toast'))
+          );
+        }
+        return Boolean(node.parentElement?.closest?.('#ai-chat-exporter-toast'));
+      }
+
       domObserver = new MutationObserver((mutations) => {
-        let hasAddedNodes = false;
+        let hasRelevantMutation = false;
         for (const m of mutations) {
-          if (m.addedNodes && m.addedNodes.length > 0) {
-            for (let i = 0; i < m.addedNodes.length; i++) {
-              const node = m.addedNodes[i];
-              if (
-                node.nodeType === 1 &&
-                node.id !== 'ai-chat-exporter-toast' &&
-                !node.closest?.('#ai-chat-exporter-toast')
-              ) {
-                hasAddedNodes = true;
+          if (m.type === 'characterData') {
+            if (!isToastNode(m.target)) {
+              hasRelevantMutation = true;
+              break;
+            }
+          } else if (m.type === 'childList') {
+            const nodes = [...(m.addedNodes || []), ...(m.removedNodes || [])];
+            for (const node of nodes) {
+              if (!isToastNode(node)) {
+                hasRelevantMutation = true;
                 break;
               }
             }
-            if (hasAddedNodes) break;
+            if (hasRelevantMutation) break;
           }
         }
 
-        if (hasAddedNodes) {
+        if (hasRelevantMutation) {
+          if (parseCache) {
+            parseCache.dirty = true;
+          }
           clearTimeout(mutationDebounceTimer);
           mutationDebounceTimer = setTimeout(() => {
-            if (parseCache) {
-              logger.debug('Chat DOM mutation detected, marking parse cache dirty');
-              parseCache.dirty = true;
-            }
+            logger.debug('Chat DOM mutation detected and debounced');
           }, 600);
         }
       });
 
       try {
-        domObserver.observe(document.body, { childList: true, subtree: true });
+        domObserver.observe(document.body, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+        });
       } catch (e) {
         logger.debug('DOM MutationObserver registration failed:', e);
       }
@@ -331,7 +347,10 @@ export default defineContentScript({
 
                 const elapsed = Date.now() - startTime;
                 if (!isPopupOpen && currentFrameIsTop && count > 0 && elapsed > 250) {
-                  showExporterToast(`⚡ ${platformName} chat ready to export (${count} messages)`);
+                  const toastMsg =
+                    chrome.i18n?.getMessage('toastChatReady', [platformName, String(count)]) ||
+                    `⚡ ${platformName} chat ready to export (${count} messages)`;
+                  showExporterToast(toastMsg);
                 }
               } catch (e) {
                 logger.error('Discover frames parse error:', e);
@@ -426,7 +445,10 @@ export default defineContentScript({
 
                 const elapsed = Date.now() - startTime;
                 if (!isPopupOpen && currentFrameIsTop && count > 0 && elapsed > 250) {
-                  showExporterToast(`⚡ ${platformName} chat ready to export (${count} messages)`);
+                  const toastMsg =
+                    chrome.i18n?.getMessage('toastChatReady', [platformName, String(count)]) ||
+                    `⚡ ${platformName} chat ready to export (${count} messages)`;
+                  showExporterToast(toastMsg);
                 }
               } catch (e) {
                 logger.error('Check availability parse threw error:', e);

--- a/entrypoints/content.js
+++ b/entrypoints/content.js
@@ -176,6 +176,80 @@ export default defineContentScript({
       }
     }
 
+    const PARSE_CACHE_TTL_MS = 90 * 1000;
+    let parseCache = null;
+    let isPopupOpen = false;
+    let domObserver = null;
+    let mutationDebounceTimer = null;
+
+    if (typeof chrome !== 'undefined' && chrome.runtime?.onConnect) {
+      chrome.runtime.onConnect.addListener((port) => {
+        if (port && port.name === 'popup-tab-session') {
+          isPopupOpen = true;
+          port.onDisconnect.addListener(() => {
+            isPopupOpen = false;
+          });
+        }
+      });
+    }
+
+    function isCacheValid(requestedMode) {
+      if (!parseCache || parseCache.dirty || !parseCache.report) return false;
+      if (parseCache.url !== window.location.href) return false;
+      if (requestedMode && parseCache.parserMode && parseCache.parserMode !== requestedMode) {
+        return false;
+      }
+      const age = Date.now() - parseCache.timestamp;
+      return age < PARSE_CACHE_TTL_MS;
+    }
+
+    function setupDomObserver() {
+      if (
+        typeof MutationObserver === 'undefined' ||
+        typeof document === 'undefined' ||
+        !document.body
+      ) {
+        return;
+      }
+      if (domObserver) return;
+
+      domObserver = new MutationObserver((mutations) => {
+        let hasAddedNodes = false;
+        for (const m of mutations) {
+          if (m.addedNodes && m.addedNodes.length > 0) {
+            for (let i = 0; i < m.addedNodes.length; i++) {
+              const node = m.addedNodes[i];
+              if (
+                node.nodeType === 1 &&
+                node.id !== 'ai-chat-exporter-toast' &&
+                !node.closest?.('#ai-chat-exporter-toast')
+              ) {
+                hasAddedNodes = true;
+                break;
+              }
+            }
+            if (hasAddedNodes) break;
+          }
+        }
+
+        if (hasAddedNodes) {
+          clearTimeout(mutationDebounceTimer);
+          mutationDebounceTimer = setTimeout(() => {
+            if (parseCache) {
+              logger.debug('Chat DOM mutation detected, marking parse cache dirty');
+              parseCache.dirty = true;
+            }
+          }, 600);
+        }
+      });
+
+      try {
+        domObserver.observe(document.body, { childList: true, subtree: true });
+      } catch (e) {
+        logger.debug('DOM MutationObserver registration failed:', e);
+      }
+    }
+
     if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
       chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         const currentFrameIsTop = typeof window === 'undefined' || window.self === window.top;
@@ -183,13 +257,42 @@ export default defineContentScript({
           `Message received: action=${request.action} on frame=${currentFrameIsTop ? 'TOP' : 'IFRAME'}`,
         );
 
+        if (request.action === 'CLEAR_CACHE') {
+          parseCache = null;
+          sendResponse({ success: true });
+          return true;
+        }
+
+        if (request.action === 'SHOW_TOAST') {
+          showExporterToast(request.message, request.toastType || 'success');
+          sendResponse({ success: true });
+          return true;
+        }
+
         if (request.action === 'DISCOVER_FRAMES') {
           detectParser();
+          setupDomObserver();
           const queryId = request.queryId;
+          const isForce = Boolean(request.force);
+          const parserMode = request.parserMode || 'auto';
+
           if (activeParser) {
             (async () => {
               try {
-                const conversation = enrichConversation(await activeParser.parse({ full: false }));
+                if (!isForce && isCacheValid(parserMode)) {
+                  logger.debug('DISCOVER_FRAMES returning cached report');
+                  chrome.runtime.sendMessage({
+                    action: 'FRAME_REPORT',
+                    queryId,
+                    data: parseCache.report,
+                  });
+                  return;
+                }
+
+                const startTime = Date.now();
+                const conversation = enrichConversation(
+                  await activeParser.parse({ full: false, parserMode }),
+                );
                 const count = conversation?.messages?.length || 0;
                 if (!currentFrameIsTop && count === 0) {
                   return;
@@ -202,18 +305,34 @@ export default defineContentScript({
                     ? activeParser.getPlatformName()
                     : activeParser.name || activeParser.constructor.name.replace('Parser', '');
 
+                const reportData = {
+                  available: true,
+                  platform: platformName,
+                  isDedicatedAi,
+                  count,
+                  title: conversation?.title || '',
+                  isTopFrame: currentFrameIsTop,
+                };
+
+                parseCache = {
+                  url: window.location.href,
+                  timestamp: Date.now(),
+                  parserMode,
+                  report: reportData,
+                  conversation,
+                  dirty: false,
+                };
+
                 chrome.runtime.sendMessage({
                   action: 'FRAME_REPORT',
                   queryId,
-                  data: {
-                    available: true,
-                    platform: platformName,
-                    isDedicatedAi,
-                    count,
-                    title: conversation?.title || '',
-                    isTopFrame: currentFrameIsTop,
-                  },
+                  data: reportData,
                 });
+
+                const elapsed = Date.now() - startTime;
+                if (!isPopupOpen && currentFrameIsTop && count > 0 && elapsed > 250) {
+                  showExporterToast(`⚡ ${platformName} chat ready to export (${count} messages)`);
+                }
               } catch (e) {
                 logger.error('Discover frames parse error:', e);
                 if (currentFrameIsTop) {
@@ -252,15 +371,29 @@ export default defineContentScript({
 
         if (request.action === 'CHECK_AVAILABILITY') {
           detectParser();
+          setupDomObserver();
+          const isForce = Boolean(request.force);
+          const parserMode = request.parserMode || 'auto';
+
           if (activeParser) {
             (async () => {
               try {
-                logger.debug('Executing activeParser.parse({ full: false })...');
-                const conversation = enrichConversation(await activeParser.parse({ full: false }));
-                logger.debug(
-                  `Availability check parsed ${conversation.messages.length} messages, title: "${conversation.title || ''}"`,
+                if (!isForce && isCacheValid(parserMode)) {
+                  logger.debug('CHECK_AVAILABILITY returning cached report');
+                  sendResponse(parseCache.report);
+                  return;
+                }
+
+                const startTime = Date.now();
+                logger.debug('Executing activeParser.parse({ full: false, parserMode })...');
+                const conversation = enrichConversation(
+                  await activeParser.parse({ full: false, parserMode }),
                 );
-                if (!currentFrameIsTop && conversation.messages.length === 0) {
+                const count = conversation?.messages?.length || 0;
+                logger.debug(
+                  `Availability check parsed ${count} messages, title: "${conversation?.title || ''}"`,
+                );
+                if (!currentFrameIsTop && count === 0) {
                   logger.debug('Subframe has 0 messages, ignoring subframe response');
                   return;
                 }
@@ -271,11 +404,30 @@ export default defineContentScript({
                 const responseData = {
                   available: true,
                   platform: platformName,
-                  count: conversation.messages.length,
-                  title: conversation.title || '',
+                  count,
+                  title: conversation?.title || '',
+                  isDedicatedAi:
+                    activeParser.name !== 'WebArticle' &&
+                    activeParser.constructor?.name !== 'ArticleParser',
+                  isTopFrame: currentFrameIsTop,
                 };
+
+                parseCache = {
+                  url: window.location.href,
+                  timestamp: Date.now(),
+                  parserMode,
+                  report: responseData,
+                  conversation,
+                  dirty: false,
+                };
+
                 logger.debug('Sending CHECK_AVAILABILITY response:', responseData);
                 sendResponse(responseData);
+
+                const elapsed = Date.now() - startTime;
+                if (!isPopupOpen && currentFrameIsTop && count > 0 && elapsed > 250) {
+                  showExporterToast(`⚡ ${platformName} chat ready to export (${count} messages)`);
+                }
               } catch (e) {
                 logger.error('Check availability parse threw error:', e);
                 if (currentFrameIsTop) {

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -8,8 +8,21 @@
     <div class="container">
       <header>
         <div class="header-row">
-          <div id="status" class="status" data-i18n="statusDetecting">Detecting...</div>
+          <div id="status" class="status">
+            <span class="status-indicator detecting"></span>
+            <span class="status-text" data-i18n="statusDetecting">Detecting...</span>
+          </div>
           <div class="header-actions">
+            <button
+              id="reparse-btn"
+              class="sidepanel-icon-btn"
+              title="Reparse Chat"
+              aria-label="Reparse Chat"
+              data-i18n-title="reparseChat"
+              data-i18n-aria-label="reparseChat"
+            >
+              ↻
+            </button>
             <button
               id="open-options-btn"
               class="sidepanel-icon-btn"

--- a/entrypoints/popup/popup.css
+++ b/entrypoints/popup/popup.css
@@ -310,6 +310,27 @@ header {
   flex-shrink: 0;
 }
 
+@keyframes pulse-dot {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.35;
+    transform: scale(0.75);
+  }
+}
+
+@keyframes spin-btn {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .status {
   font-size: 11px;
   font-weight: 600;
@@ -321,10 +342,11 @@ header {
   align-items: center;
   gap: 5px;
   border: 1px solid rgba(16, 185, 129, 0.25);
-  max-width: calc(100% - 36px);
+  max-width: calc(100% - 76px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: all 0.2s ease;
 }
 
 .status::before {
@@ -333,6 +355,51 @@ header {
   width: 6px;
   height: 6px;
   border-radius: 50%;
+  background-color: var(--status-color);
+  box-shadow: 0 0 6px var(--status-color);
+  flex-shrink: 0;
+}
+
+.status-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status.status-detecting,
+.status.status-connecting,
+.status.status-scanning {
+  color: #f59e0b;
+  background-color: rgba(245, 158, 11, 0.1);
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
+.status.status-detecting::before,
+.status.status-connecting::before,
+.status.status-scanning::before {
+  background-color: #f59e0b;
+  box-shadow: 0 0 6px #f59e0b;
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
+.status.status-error {
+  color: #ef4444;
+  background-color: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+.status.status-error::before {
+  background-color: #ef4444;
+  box-shadow: 0 0 6px #ef4444;
+}
+
+.status.status-ready {
+  color: var(--status-color);
+  background-color: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.25);
+}
+
+.status.status-ready::before {
   background-color: var(--status-color);
   box-shadow: 0 0 6px var(--status-color);
 }
@@ -352,6 +419,12 @@ header {
 .sidepanel-icon-btn:hover {
   background-color: var(--secondary-hover);
   border-color: var(--accent-color);
+}
+
+.sidepanel-icon-btn.spin {
+  animation: spin-btn 0.75s linear infinite;
+  pointer-events: none;
+  opacity: 0.8;
 }
 
 .chat-info {

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   applyI18n();
 
   const statusEl = document.getElementById('status');
+  const reparseBtn = document.getElementById('reparse-btn');
   const chatInfoEl = document.getElementById('chat-info');
   const actionsEl = document.getElementById('actions');
   const errorEl = document.getElementById('error-msg');
@@ -53,6 +54,41 @@ document.addEventListener('DOMContentLoaded', async () => {
   const previewableFormats = new Set(['markdown', 'json', 'html', 'doc', 'png', 'pdf']);
   const copyableFormats = new Set(['markdown', 'json', 'html']);
 
+  function setStatus(state, message) {
+    if (!statusEl) return;
+    statusEl.className = `status status-${state}`;
+    let textNode = statusEl.querySelector('.status-text');
+    let indicator = statusEl.querySelector('.status-indicator');
+    if (!indicator || !textNode) {
+      statusEl.innerHTML = `<span class="status-indicator ${state}"></span><span class="status-text"></span>`;
+      textNode = statusEl.querySelector('.status-text');
+    }
+    if (textNode) {
+      textNode.textContent = message;
+    } else {
+      statusEl.textContent = message;
+    }
+  }
+
+  let sessionPort = null;
+  function establishSession(targetTabId) {
+    if (sessionPort) {
+      try {
+        sessionPort.disconnect();
+      } catch {
+        // Ignore
+      }
+      sessionPort = null;
+    }
+    if (typeof chrome !== 'undefined' && chrome.tabs?.connect && targetTabId) {
+      try {
+        sessionPort = chrome.tabs.connect(targetTabId, { name: 'popup-tab-session' });
+      } catch {
+        // Ignore
+      }
+    }
+  }
+
   const openOptionsBtn = document.getElementById('open-options-btn');
   if (openOptionsBtn) {
     openOptionsBtn.addEventListener('click', () => {
@@ -60,6 +96,20 @@ document.addEventListener('DOMContentLoaded', async () => {
         chrome.runtime.openOptionsPage();
       } else {
         chrome.tabs.create({ url: chrome.runtime.getURL('options.html') });
+      }
+    });
+  }
+
+  if (reparseBtn) {
+    reparseBtn.addEventListener('click', async () => {
+      if (reparseBtn.disabled) return;
+      reparseBtn.classList.add('spin');
+      reparseBtn.disabled = true;
+      try {
+        await checkAvailability({ force: true });
+      } finally {
+        reparseBtn.classList.remove('spin');
+        reparseBtn.disabled = false;
       }
     });
   }
@@ -157,7 +207,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (!tab) {
     logger.warn('No active tab found');
-    statusEl.textContent = 'Error: No active tab';
+    setStatus('error', 'Error: No active tab');
     return;
   }
 
@@ -186,25 +236,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     return score;
   }
 
-  async function discoverBestFrame(tabId) {
+  async function discoverBestFrame(tabId, options = {}) {
     return new Promise((resolve) => {
       const reports = [];
       const queryId = `${Date.now()}_${Math.random()}`;
-
-      const listener = (msg, sender) => {
-        if (msg?.action === 'FRAME_REPORT' && msg?.queryId === queryId && msg.data) {
-          const fid =
-            typeof sender.frameId === 'number' ? sender.frameId : msg.data.isTopFrame ? 0 : null;
-          reports.push({
-            ...msg.data,
-            frameId: fid,
-          });
-        }
-      };
-
-      if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
-        chrome.runtime.onMessage.addListener(listener);
-      }
 
       let resolved = false;
       const finish = () => {
@@ -221,27 +256,78 @@ document.addEventListener('DOMContentLoaded', async () => {
         resolve(reports[0]);
       };
 
-      chrome.tabs.sendMessage(tabId, { action: 'DISCOVER_FRAMES', queryId }).catch(() => {});
-      setTimeout(finish, 200);
+      const listener = (msg, sender) => {
+        if (msg?.action === 'FRAME_REPORT' && msg?.queryId === queryId && msg.data) {
+          const fid =
+            typeof sender.frameId === 'number' ? sender.frameId : msg.data.isTopFrame ? 0 : null;
+          reports.push({
+            ...msg.data,
+            frameId: fid,
+          });
+
+          if (msg.data.platform) {
+            setStatus(
+              'scanning',
+              `${t('statusScanning') || 'Scanning messages...'} (${msg.data.platform})`,
+            );
+          }
+
+          // Fast resolution if dedicated AI report found
+          if (msg.data.available && msg.data.isDedicatedAi && msg.data.count > 0) {
+            finish();
+          }
+        }
+      };
+
+      if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
+        chrome.runtime.onMessage.addListener(listener);
+      }
+
+      chrome.tabs
+        .sendMessage(tabId, {
+          action: 'DISCOVER_FRAMES',
+          queryId,
+          force: Boolean(options.force),
+          parserMode: storedSettings.parserMode || 'auto',
+        })
+        .catch(() => {});
+
+      setTimeout(finish, 350);
     });
   }
 
   const MAX_RETRIES = 3;
   const RETRY_DELAY_MS = 500;
 
-  async function checkAvailability() {
+  async function checkAvailability(options = {}) {
+    const isForce = Boolean(options.force);
     tab = await getActiveTab();
-    logger.debug('checkAvailability() starting for tab:', tab?.id, tab?.url);
+    logger.debug('checkAvailability() starting for tab:', tab?.id, tab?.url, { isForce });
     if (!tab || !tab.id) {
       logger.warn('Tab or Tab ID invalid');
-      statusEl.textContent = 'Error: No active tab';
+      setStatus('error', 'Error: No active tab');
       showError();
       return;
     }
+
+    establishSession(tab.id);
+
+    if (isForce) {
+      setStatus('scanning', t('statusScanning') || 'Scanning messages...');
+    } else {
+      setStatus('connecting', t('statusConnecting') || 'Connecting...');
+    }
+
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
+        if (!isForce && attempt === 0) {
+          setStatus('connecting', t('statusConnecting') || 'Connecting...');
+        } else {
+          setStatus('detecting', t('statusDetecting') || 'Detecting...');
+        }
+
         logger.debug(`Attempt ${attempt + 1}/${MAX_RETRIES}: Discovering frames in tab ${tab.id}`);
-        let bestReport = await discoverBestFrame(tab.id);
+        let bestReport = await discoverBestFrame(tab.id, options);
         let response = null;
 
         if (bestReport && bestReport.available) {
@@ -249,8 +335,11 @@ document.addEventListener('DOMContentLoaded', async () => {
           response = bestReport;
         } else if (!bestReport) {
           logger.debug('No DISCOVER_FRAMES reports, falling back to CHECK_AVAILABILITY');
+          setStatus('scanning', t('statusScanning') || 'Scanning messages...');
           response = await chrome.tabs.sendMessage(tab.id, {
             action: 'CHECK_AVAILABILITY',
+            force: isForce,
+            parserMode: storedSettings.parserMode || 'auto',
           });
           activeTargetFrameId = null;
         }
@@ -260,7 +349,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           logger.info(
             `Successfully connected to platform: ${response.platform} with ${response.count} messages (frameId: ${activeTargetFrameId})`,
           );
-          statusEl.textContent = `${t('statusReady') || 'Ready'}: ${response.platform}`;
+          setStatus('ready', `${t('statusReady') || 'Ready'}: ${response.platform}`);
           const platformName = response.platform || 'AI';
           const displayTitle = resolveConversationTitle(response.title, platformName, {
             title: tab.title,
@@ -371,7 +460,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function showError() {
-    statusEl.textContent = t('statusError') || 'Not Supported';
+    setStatus('error', t('statusError') || 'Not Supported');
     errorEl.classList.remove('hidden');
     if (copilotRedirectBox) {
       const isCopilotMs = Boolean(tab?.url && tab.url.includes('copilot.microsoft.com'));
@@ -424,10 +513,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             url: chrome.runtime.getURL('preview.html'),
           });
 
-          statusEl.textContent = t('statusExportSuccess') || 'Export Successful!';
+          setStatus('ready', t('statusExportSuccess') || 'Export Successful!');
         } else {
-          statusEl.textContent =
-            (t('statusError') || 'Export Failed') + ': ' + (response?.error || 'Unknown');
+          setStatus(
+            'error',
+            (t('statusError') || 'Export Failed') + ': ' + (response?.error || 'Unknown'),
+          );
         }
       } else {
         const response = await sendTabMessage({
@@ -441,14 +532,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
 
         if (response && response.success) {
-          statusEl.textContent = t('statusExportSuccess') || 'Export Successful!';
+          setStatus('ready', t('statusExportSuccess') || 'Export Successful!');
         } else {
-          statusEl.textContent =
-            (t('statusError') || 'Export Failed') + ': ' + (response?.error || 'Unknown');
+          setStatus(
+            'error',
+            (t('statusError') || 'Export Failed') + ': ' + (response?.error || 'Unknown'),
+          );
         }
       }
     } catch (e) {
-      statusEl.textContent = 'Error: ' + e.message;
+      setStatus('error', 'Error: ' + e.message);
     } finally {
       exportBtn.disabled = false;
       updateCopyButtonVisibility();
@@ -459,6 +552,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const format = formatSelect.value;
     copyBtn.disabled = true;
     copyBtn.textContent = t('statusExporting') || 'Copying...';
+    setStatus('exporting', t('statusExporting') || 'Copying...');
 
     try {
       const response = await sendTabMessage({
@@ -491,12 +585,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         } else {
           await navigator.clipboard.writeText(response.content);
         }
-        statusEl.textContent = t('statusCopied') || 'Copied to clipboard!';
+        setStatus('ready', t('statusCopied') || 'Copied to clipboard!');
       } else {
-        statusEl.textContent = 'Copy Failed: ' + (response?.error || 'Unknown');
+        setStatus('error', 'Copy Failed: ' + (response?.error || 'Unknown'));
       }
     } catch (e) {
-      statusEl.textContent = 'Error: ' + e.message;
+      setStatus('error', 'Error: ' + e.message);
     } finally {
       copyBtn.disabled = false;
       copyBtn.textContent = t('copyChat') || '📋 Copy Chat';
@@ -507,6 +601,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const format = formatSelect.value;
     previewBtn.disabled = true;
     previewBtn.textContent = t('loadingContent') || 'Opening...';
+    setStatus('exporting', t('loadingContent') || 'Opening...');
 
     try {
       const formatToRequest = format === 'pdf' ? 'html' : format === 'png' ? 'markdown' : format;
@@ -536,12 +631,12 @@ document.addEventListener('DOMContentLoaded', async () => {
           url: chrome.runtime.getURL('preview.html'),
         });
 
-        statusEl.textContent = t('statusOpenedInTab') || 'Opened in New Tab!';
+        setStatus('ready', t('statusOpenedInTab') || 'Opened in New Tab!');
       } else {
-        statusEl.textContent = 'Preview Failed: ' + (response?.error || 'Unknown');
+        setStatus('error', 'Preview Failed: ' + (response?.error || 'Unknown'));
       }
     } catch (e) {
-      statusEl.textContent = 'Error: ' + e.message;
+      setStatus('error', 'Error: ' + e.message);
     } finally {
       previewBtn.disabled = false;
       previewBtn.textContent = t('openInTab') || '👁️ Open in Tab';
@@ -555,6 +650,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const targetPlatform = continueTargetSelect ? continueTargetSelect.value : 'chatgpt';
       transferBtn.disabled = true;
       transferBtn.textContent = t('statusExporting') || 'Transferring...';
+      setStatus('exporting', t('statusExporting') || 'Transferring...');
 
       try {
         const response = await sendTabMessage({
@@ -569,12 +665,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             title: filenameInput ? filenameInput.value : 'AI Conversation',
             payload: response.payload,
           });
-          statusEl.textContent = `Opening ${targetPlatform}...`;
+          setStatus('ready', `Opening ${targetPlatform}...`);
         } else {
-          statusEl.textContent = 'Transfer Failed: ' + (response?.error || 'No content');
+          setStatus('error', 'Transfer Failed: ' + (response?.error || 'No content'));
         }
       } catch (e) {
-        statusEl.textContent = 'Error: ' + e.message;
+        setStatus('error', 'Error: ' + e.message);
       } finally {
         transferBtn.disabled = false;
         transferBtn.textContent = t('transferBtn') || '↗ Transfer';

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -271,11 +271,6 @@ document.addEventListener('DOMContentLoaded', async () => {
               `${t('statusScanning') || 'Scanning messages...'} (${msg.data.platform})`,
             );
           }
-
-          // Fast resolution if dedicated AI report found
-          if (msg.data.available && msg.data.isDedicatedAi && msg.data.count > 0) {
-            finish();
-          }
         }
       };
 
@@ -298,10 +293,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const MAX_RETRIES = 3;
   const RETRY_DELAY_MS = 500;
+  let availabilityCheckSeq = 0;
 
   async function checkAvailability(options = {}) {
+    const currentSeq = ++availabilityCheckSeq;
     const isForce = Boolean(options.force);
     tab = await getActiveTab();
+    if (currentSeq !== availabilityCheckSeq) return;
     logger.debug('checkAvailability() starting for tab:', tab?.id, tab?.url, { isForce });
     if (!tab || !tab.id) {
       logger.warn('Tab or Tab ID invalid');
@@ -319,6 +317,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      if (currentSeq !== availabilityCheckSeq) return;
       try {
         if (!isForce && attempt === 0) {
           setStatus('connecting', t('statusConnecting') || 'Connecting...');
@@ -328,6 +327,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         logger.debug(`Attempt ${attempt + 1}/${MAX_RETRIES}: Discovering frames in tab ${tab.id}`);
         let bestReport = await discoverBestFrame(tab.id, options);
+        if (currentSeq !== availabilityCheckSeq) return;
         let response = null;
 
         if (bestReport && bestReport.available) {

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -509,8 +509,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             includeImages: includeImagesCheckbox ? includeImagesCheckbox.checked : true,
           });
 
+          const formatCode = format === 'markdown' ? 'md' : format;
           await chrome.tabs.create({
-            url: chrome.runtime.getURL('preview.html'),
+            url:
+              chrome.runtime.getURL('preview.html') +
+              `?export_format=${encodeURIComponent(formatCode)}`,
           });
 
           setStatus('ready', t('statusExportSuccess') || 'Export Successful!');
@@ -627,8 +630,12 @@ document.addEventListener('DOMContentLoaded', async () => {
           includeImages: includeImagesCheckbox ? includeImagesCheckbox.checked : true,
         });
 
+        const activeFormat = formatSelect ? formatSelect.value : 'markdown';
+        const formatCode = activeFormat === 'markdown' ? 'md' : activeFormat;
         await chrome.tabs.create({
-          url: chrome.runtime.getURL('preview.html'),
+          url:
+            chrome.runtime.getURL('preview.html') +
+            `?export_format=${encodeURIComponent(formatCode)}`,
         });
 
         setStatus('ready', t('statusOpenedInTab') || 'Opened in New Tab!');

--- a/entrypoints/preview/index.html
+++ b/entrypoints/preview/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Chat Export Preview</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
+    <link rel="shortcut icon" href="/icons/favicon.ico" />
     <link rel="stylesheet" href="preview.css" />
   </head>
   <body>
@@ -182,17 +185,8 @@
       <main class="preview-main">
         <aside id="turn-selector-drawer" class="turn-selector-drawer hidden">
           <div class="drawer-header">
-            <h3 data-i18n="turnSelectorTitle">Select Messages</h3>
-            <div class="drawer-actions">
-              <button id="turn-select-all-btn" class="drawer-btn" data-i18n="selectAll">
-                Select All
-              </button>
-              <button id="turn-deselect-all-btn" class="drawer-btn" data-i18n="deselectAll">
-                Deselect All
-              </button>
-              <button id="turn-done-btn" class="drawer-btn drawer-btn-primary" data-i18n="done">
-                Done
-              </button>
+            <div class="drawer-header-top">
+              <h3 data-i18n="turnSelectorTitle">Select Messages</h3>
               <button
                 id="turn-drawer-close-btn"
                 class="drawer-close-btn"
@@ -200,6 +194,21 @@
                 data-i18n-title="closeSelector"
               >
                 &times;
+              </button>
+            </div>
+            <div class="drawer-actions">
+              <button id="turn-select-all-btn" class="drawer-btn" data-i18n="selectAll">All</button>
+              <button id="turn-select-prompts-btn" class="drawer-btn" data-i18n="selectPrompts">
+                Prompts
+              </button>
+              <button id="turn-select-responses-btn" class="drawer-btn" data-i18n="selectResponses">
+                Responses
+              </button>
+              <button id="turn-deselect-all-btn" class="drawer-btn" data-i18n="deselectAll">
+                None
+              </button>
+              <button id="turn-done-btn" class="drawer-btn drawer-btn-primary" data-i18n="done">
+                Done
               </button>
             </div>
           </div>

--- a/entrypoints/preview/preview.css
+++ b/entrypoints/preview/preview.css
@@ -486,15 +486,17 @@ h1 {
 .preview-main {
   flex: 1;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   height: calc(100vh - 65px);
   overflow: hidden;
   box-shadow: none;
+  position: relative;
 }
 
 .code-wrapper {
   flex: 1;
   height: 100%;
+  min-width: 0;
   background-color: var(--code-bg);
   border: none;
   border-radius: 0;
@@ -595,6 +597,7 @@ code {
 .render-wrapper {
   flex: 1;
   height: 100%;
+  min-width: 0;
   background-color: var(--card-bg);
   border: none;
   border-radius: 0;
@@ -671,11 +674,18 @@ html[data-theme='dark'] .png-warning-banner {
   padding: 12px 16px;
   border-bottom: 1px solid var(--border-color);
   display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.drawer-header-top {
+  display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.drawer-header h3 {
+.drawer-header h3,
+.drawer-header-top h3 {
   margin: 0;
   font-size: 14px;
   font-weight: 600;
@@ -685,6 +695,7 @@ html[data-theme='dark'] .png-warning-banner {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex-wrap: wrap;
 }
 
 .drawer-btn {

--- a/entrypoints/preview/preview.js
+++ b/entrypoints/preview/preview.js
@@ -629,7 +629,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!code || typeof window === 'undefined' || !window.location) return;
     try {
       const url = new URL(window.location.href);
-      if (url.searchParams.get('export_format') !== code) {
+      if (url.searchParams.get('export_format') !== code || url.searchParams.has('format')) {
         url.searchParams.set('export_format', code);
         if (url.searchParams.has('format')) {
           url.searchParams.delete('format');

--- a/entrypoints/preview/preview.js
+++ b/entrypoints/preview/preview.js
@@ -345,6 +345,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const turnCountBadge = document.getElementById('turn-count-badge');
   const turnDrawer = document.getElementById('turn-selector-drawer');
   const turnSelectAllBtn = document.getElementById('turn-select-all-btn');
+  const turnSelectPromptsBtn = document.getElementById('turn-select-prompts-btn');
+  const turnSelectResponsesBtn = document.getElementById('turn-select-responses-btn');
   const turnDeselectAllBtn = document.getElementById('turn-deselect-all-btn');
   const turnCloseBtn = document.getElementById('turn-drawer-close-btn');
   const turnListContainer = document.getElementById('turn-list-container');
@@ -479,6 +481,32 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
     });
   }
+  if (turnSelectPromptsBtn) {
+    turnSelectPromptsBtn.addEventListener('click', () => {
+      if (conversation?.messages) {
+        selectedIndices = new Set(
+          conversation.messages
+            .map((msg, idx) => (msg.role === 'User' ? idx : null))
+            .filter((idx) => idx !== null),
+        );
+        renderTurnList();
+        recalculateContent();
+      }
+    });
+  }
+  if (turnSelectResponsesBtn) {
+    turnSelectResponsesBtn.addEventListener('click', () => {
+      if (conversation?.messages) {
+        selectedIndices = new Set(
+          conversation.messages
+            .map((msg, idx) => (msg.role !== 'User' ? idx : null))
+            .filter((idx) => idx !== null),
+        );
+        renderTurnList();
+        recalculateContent();
+      }
+    });
+  }
   if (turnDeselectAllBtn) {
     turnDeselectAllBtn.addEventListener('click', () => {
       selectedIndices.clear();
@@ -562,8 +590,60 @@ document.addEventListener('DOMContentLoaded', async () => {
     downloadBtn.innerHTML = `${icon} ${label}`;
   };
 
+  const mapTabToFormatParam = (tabName) => {
+    switch (tabName) {
+      case 'markdown':
+        return 'md';
+      case 'json':
+        return 'json';
+      case 'html-render':
+        return 'html';
+      case 'html-source':
+        return 'source';
+      case 'doc':
+        return 'doc';
+      case 'png':
+        return 'png';
+      case 'pdf':
+        return 'pdf';
+      default:
+        return null;
+    }
+  };
+
+  const mapFormatParamToTab = (param) => {
+    if (!param) return null;
+    const p = String(param).trim().toLowerCase();
+    if (p === 'md' || p === 'markdown') return 'markdown';
+    if (p === 'json') return 'json';
+    if (p === 'html' || p === 'live' || p === 'html-render') return 'html-render';
+    if (p === 'source' || p === 'html-source') return 'html-source';
+    if (p === 'doc' || p === 'word') return 'doc';
+    if (p === 'png' || p === 'image') return 'png';
+    if (p === 'pdf') return 'pdf';
+    return null;
+  };
+
+  const syncUrlFormat = (tabName) => {
+    const code = mapTabToFormatParam(tabName);
+    if (!code || typeof window === 'undefined' || !window.location) return;
+    try {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('export_format') !== code) {
+        url.searchParams.set('export_format', code);
+        if (url.searchParams.has('format')) {
+          url.searchParams.delete('format');
+        }
+        window.history.replaceState(null, '', url.pathname + url.search + url.hash);
+      }
+    } catch {
+      // Ignore URL sync errors in restricted environments or tests
+    }
+  };
+
   const switchTab = (tabName) => {
     currentActiveTab = tabName;
+    syncUrlFormat(tabName);
     const buttons = formatTabsContainer.querySelectorAll('.control-btn');
     buttons.forEach((btn) => {
       if (btn.getAttribute('data-tab') === tabName) {
@@ -775,6 +855,19 @@ document.addEventListener('DOMContentLoaded', async () => {
       initialTab = 'pdf';
     } else if (initialFormat === 'html') {
       initialTab = 'html-render';
+    }
+
+    try {
+      if (typeof window !== 'undefined' && window.location && window.location.search) {
+        const searchParams = new URLSearchParams(window.location.search);
+        const urlFormat = searchParams.get('export_format') || searchParams.get('format');
+        const mappedUrlTab = mapFormatParamToTab(urlFormat);
+        if (mappedUrlTab) {
+          initialTab = mappedUrlTab;
+        }
+      }
+    } catch {
+      // Fall back to storage initialFormat
     }
 
     if (autoPrint && (initialFormat === 'pdf' || initialFormat === 'html')) {

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -310,6 +310,27 @@ header {
   flex-shrink: 0;
 }
 
+@keyframes pulse-dot {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.35;
+    transform: scale(0.75);
+  }
+}
+
+@keyframes spin-btn {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .status {
   font-size: 11px;
   font-weight: 600;
@@ -321,10 +342,11 @@ header {
   align-items: center;
   gap: 5px;
   border: 1px solid rgba(16, 185, 129, 0.25);
-  max-width: calc(100% - 36px);
+  max-width: calc(100% - 76px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: all 0.2s ease;
 }
 
 .status::before {
@@ -333,6 +355,51 @@ header {
   width: 6px;
   height: 6px;
   border-radius: 50%;
+  background-color: var(--status-color);
+  box-shadow: 0 0 6px var(--status-color);
+  flex-shrink: 0;
+}
+
+.status-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status.status-detecting,
+.status.status-connecting,
+.status.status-scanning {
+  color: #f59e0b;
+  background-color: rgba(245, 158, 11, 0.1);
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
+.status.status-detecting::before,
+.status.status-connecting::before,
+.status.status-scanning::before {
+  background-color: #f59e0b;
+  box-shadow: 0 0 6px #f59e0b;
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
+.status.status-error {
+  color: #ef4444;
+  background-color: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+.status.status-error::before {
+  background-color: #ef4444;
+  box-shadow: 0 0 6px #ef4444;
+}
+
+.status.status-ready {
+  color: var(--status-color);
+  background-color: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.25);
+}
+
+.status.status-ready::before {
   background-color: var(--status-color);
   box-shadow: 0 0 6px var(--status-color);
 }
@@ -352,6 +419,12 @@ header {
 .sidepanel-icon-btn:hover {
   background-color: var(--secondary-hover);
   border-color: var(--accent-color);
+}
+
+.sidepanel-icon-btn.spin {
+  animation: spin-btn 0.75s linear infinite;
+  pointer-events: none;
+  opacity: 0.8;
 }
 
 .chat-info {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -8,8 +8,21 @@
     <div class="container">
       <header>
         <div class="header-row">
-          <div id="status" class="status" data-i18n="statusDetecting">Detecting...</div>
+          <div id="status" class="status">
+            <span class="status-indicator detecting"></span>
+            <span class="status-text" data-i18n="statusDetecting">Detecting...</span>
+          </div>
           <div class="header-actions">
+            <button
+              id="reparse-btn"
+              class="sidepanel-icon-btn"
+              title="Reparse Chat"
+              aria-label="Reparse Chat"
+              data-i18n-title="reparseChat"
+              data-i18n-aria-label="reparseChat"
+            >
+              ↻
+            </button>
             <button
               id="open-options-btn"
               class="sidepanel-icon-btn"

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -509,8 +509,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             includeImages: includeImagesCheckbox ? includeImagesCheckbox.checked : true,
           });
 
+          const formatCode = format === 'markdown' ? 'md' : format;
           await chrome.tabs.create({
-            url: chrome.runtime.getURL('popup/preview.html'),
+            url:
+              chrome.runtime.getURL('popup/preview.html') +
+              `?export_format=${encodeURIComponent(formatCode)}`,
           });
 
           setStatus('ready', t('statusExportSuccess') || 'Export Successful!');
@@ -627,8 +630,12 @@ document.addEventListener('DOMContentLoaded', async () => {
           includeImages: includeImagesCheckbox ? includeImagesCheckbox.checked : true,
         });
 
+        const activeFormat = formatSelect ? formatSelect.value : 'markdown';
+        const formatCode = activeFormat === 'markdown' ? 'md' : activeFormat;
         await chrome.tabs.create({
-          url: chrome.runtime.getURL('popup/preview.html'),
+          url:
+            chrome.runtime.getURL('popup/preview.html') +
+            `?export_format=${encodeURIComponent(formatCode)}`,
         });
 
         setStatus('ready', t('statusOpenedInTab') || 'Opened in New Tab!');

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -271,11 +271,6 @@ document.addEventListener('DOMContentLoaded', async () => {
               `${t('statusScanning') || 'Scanning messages...'} (${msg.data.platform})`,
             );
           }
-
-          // Fast resolution if dedicated AI report found
-          if (msg.data.available && msg.data.isDedicatedAi && msg.data.count > 0) {
-            finish();
-          }
         }
       };
 
@@ -298,10 +293,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const MAX_RETRIES = 3;
   const RETRY_DELAY_MS = 500;
+  let availabilityCheckSeq = 0;
 
   async function checkAvailability(options = {}) {
+    const currentSeq = ++availabilityCheckSeq;
     const isForce = Boolean(options.force);
     tab = await getActiveTab();
+    if (currentSeq !== availabilityCheckSeq) return;
     logger.debug('checkAvailability() starting for tab:', tab?.id, tab?.url, { isForce });
     if (!tab || !tab.id) {
       logger.warn('Tab or Tab ID invalid');
@@ -319,6 +317,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      if (currentSeq !== availabilityCheckSeq) return;
       try {
         if (!isForce && attempt === 0) {
           setStatus('connecting', t('statusConnecting') || 'Connecting...');
@@ -328,6 +327,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         logger.debug(`Attempt ${attempt + 1}/${MAX_RETRIES}: Discovering frames in tab ${tab.id}`);
         let bestReport = await discoverBestFrame(tab.id, options);
+        if (currentSeq !== availabilityCheckSeq) return;
         let response = null;
 
         if (bestReport && bestReport.available) {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   applyI18n();
 
   const statusEl = document.getElementById('status');
+  const reparseBtn = document.getElementById('reparse-btn');
   const chatInfoEl = document.getElementById('chat-info');
   const actionsEl = document.getElementById('actions');
   const errorEl = document.getElementById('error-msg');
@@ -53,6 +54,41 @@ document.addEventListener('DOMContentLoaded', async () => {
   const previewableFormats = new Set(['markdown', 'json', 'html', 'doc', 'png', 'pdf']);
   const copyableFormats = new Set(['markdown', 'json', 'html']);
 
+  function setStatus(state, message) {
+    if (!statusEl) return;
+    statusEl.className = `status status-${state}`;
+    let textNode = statusEl.querySelector('.status-text');
+    let indicator = statusEl.querySelector('.status-indicator');
+    if (!indicator || !textNode) {
+      statusEl.innerHTML = `<span class="status-indicator ${state}"></span><span class="status-text"></span>`;
+      textNode = statusEl.querySelector('.status-text');
+    }
+    if (textNode) {
+      textNode.textContent = message;
+    } else {
+      statusEl.textContent = message;
+    }
+  }
+
+  let sessionPort = null;
+  function establishSession(targetTabId) {
+    if (sessionPort) {
+      try {
+        sessionPort.disconnect();
+      } catch {
+        // Ignore
+      }
+      sessionPort = null;
+    }
+    if (typeof chrome !== 'undefined' && chrome.tabs?.connect && targetTabId) {
+      try {
+        sessionPort = chrome.tabs.connect(targetTabId, { name: 'popup-tab-session' });
+      } catch {
+        // Ignore
+      }
+    }
+  }
+
   const openOptionsBtn = document.getElementById('open-options-btn');
   if (openOptionsBtn) {
     openOptionsBtn.addEventListener('click', () => {
@@ -64,11 +100,27 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   }
 
+  if (reparseBtn) {
+    reparseBtn.addEventListener('click', async () => {
+      if (reparseBtn.disabled) return;
+      reparseBtn.classList.add('spin');
+      reparseBtn.disabled = true;
+      try {
+        await checkAvailability({ force: true });
+      } finally {
+        reparseBtn.classList.remove('spin');
+        reparseBtn.disabled = false;
+      }
+    });
+  }
+
   const reportIssueLink = document.getElementById('report-issue-link');
   if (reportIssueLink) {
     reportIssueLink.addEventListener('click', (e) => {
       e.preventDefault();
-      chrome.tabs.create({ url: reportIssueLink.href });
+      const issueUrl =
+        'https://github.com/Covai-Labs/ai-chat-exporter/issues/new?template=bug_report.md';
+      chrome.tabs.create({ url: issueUrl });
     });
   }
 
@@ -76,24 +128,23 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (decantLink) {
     decantLink.addEventListener('click', (e) => {
       e.preventDefault();
-      chrome.tabs.create({ url: 'https://decant.in/' });
+      chrome.tabs.create({ url: decantLink.href });
     });
   }
 
   const copilotRedirectBox = document.getElementById('copilot-redirect-box');
   const copilotRedirectBtn = document.getElementById('copilot-redirect-btn');
   if (copilotRedirectBtn) {
-    copilotRedirectBtn.addEventListener('click', () => {
-      const isEdge = /Edg\//.test(navigator.userAgent);
-      if (isEdge) {
-        chrome.tabs.create({ url: 'edge://copilot' });
+    copilotRedirectBtn.addEventListener('click', async () => {
+      if (tab && tab.url) {
+        const targetUrl = tab.url.replace('copilot.microsoft.com', 'copilot.com');
+        chrome.tabs.create({ url: targetUrl });
       } else {
         chrome.tabs.create({ url: 'https://copilot.com/' });
       }
     });
   }
 
-  // Load saved defaults from chrome.storage.sync
   const storedSettings = await chrome.storage.sync.get([
     'theme',
     'uiLanguage',
@@ -109,7 +160,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     chrome.storage.onChanged.addListener(async (changes, areaName) => {
       if (areaName === 'sync') {
         if (changes.theme) {
-          applyTheme(changes.theme.newValue || 'system');
+          storedSettings.theme = changes.theme.newValue || 'system';
+          applyTheme(storedSettings.theme);
         }
         if (changes.uiLanguage) {
           await initI18n(changes.uiLanguage.newValue || 'auto');
@@ -146,7 +198,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   }
 
-  // Get current tab
   let tab = await getActiveTab();
   logger.debug('Active tab detected:', {
     id: tab?.id,
@@ -156,7 +207,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (!tab) {
     logger.warn('No active tab found');
-    statusEl.textContent = 'Error: No active tab';
+    setStatus('error', 'Error: No active tab');
     return;
   }
 
@@ -185,25 +236,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     return score;
   }
 
-  async function discoverBestFrame(tabId) {
+  async function discoverBestFrame(tabId, options = {}) {
     return new Promise((resolve) => {
       const reports = [];
       const queryId = `${Date.now()}_${Math.random()}`;
-
-      const listener = (msg, sender) => {
-        if (msg?.action === 'FRAME_REPORT' && msg?.queryId === queryId && msg.data) {
-          const fid =
-            typeof sender.frameId === 'number' ? sender.frameId : msg.data.isTopFrame ? 0 : null;
-          reports.push({
-            ...msg.data,
-            frameId: fid,
-          });
-        }
-      };
-
-      if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
-        chrome.runtime.onMessage.addListener(listener);
-      }
 
       let resolved = false;
       const finish = () => {
@@ -220,28 +256,78 @@ document.addEventListener('DOMContentLoaded', async () => {
         resolve(reports[0]);
       };
 
-      chrome.tabs.sendMessage(tabId, { action: 'DISCOVER_FRAMES', queryId }).catch(() => {});
-      setTimeout(finish, 200);
+      const listener = (msg, sender) => {
+        if (msg?.action === 'FRAME_REPORT' && msg?.queryId === queryId && msg.data) {
+          const fid =
+            typeof sender.frameId === 'number' ? sender.frameId : msg.data.isTopFrame ? 0 : null;
+          reports.push({
+            ...msg.data,
+            frameId: fid,
+          });
+
+          if (msg.data.platform) {
+            setStatus(
+              'scanning',
+              `${t('statusScanning') || 'Scanning messages...'} (${msg.data.platform})`,
+            );
+          }
+
+          // Fast resolution if dedicated AI report found
+          if (msg.data.available && msg.data.isDedicatedAi && msg.data.count > 0) {
+            finish();
+          }
+        }
+      };
+
+      if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
+        chrome.runtime.onMessage.addListener(listener);
+      }
+
+      chrome.tabs
+        .sendMessage(tabId, {
+          action: 'DISCOVER_FRAMES',
+          queryId,
+          force: Boolean(options.force),
+          parserMode: storedSettings.parserMode || 'auto',
+        })
+        .catch(() => {});
+
+      setTimeout(finish, 350);
     });
   }
 
-  // Ping the content script to see if a parser is available.
   const MAX_RETRIES = 3;
   const RETRY_DELAY_MS = 500;
 
-  async function checkAvailability() {
+  async function checkAvailability(options = {}) {
+    const isForce = Boolean(options.force);
     tab = await getActiveTab();
-    logger.debug('checkAvailability() starting for tab:', tab?.id, tab?.url);
+    logger.debug('checkAvailability() starting for tab:', tab?.id, tab?.url, { isForce });
     if (!tab || !tab.id) {
       logger.warn('Tab or Tab ID invalid');
-      statusEl.textContent = 'Error: No active tab';
+      setStatus('error', 'Error: No active tab');
       showError();
       return;
     }
+
+    establishSession(tab.id);
+
+    if (isForce) {
+      setStatus('scanning', t('statusScanning') || 'Scanning messages...');
+    } else {
+      setStatus('connecting', t('statusConnecting') || 'Connecting...');
+    }
+
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
+        if (!isForce && attempt === 0) {
+          setStatus('connecting', t('statusConnecting') || 'Connecting...');
+        } else {
+          setStatus('detecting', t('statusDetecting') || 'Detecting...');
+        }
+
         logger.debug(`Attempt ${attempt + 1}/${MAX_RETRIES}: Discovering frames in tab ${tab.id}`);
-        let bestReport = await discoverBestFrame(tab.id);
+        let bestReport = await discoverBestFrame(tab.id, options);
         let response = null;
 
         if (bestReport && bestReport.available) {
@@ -249,8 +335,11 @@ document.addEventListener('DOMContentLoaded', async () => {
           response = bestReport;
         } else if (!bestReport) {
           logger.debug('No DISCOVER_FRAMES reports, falling back to CHECK_AVAILABILITY');
+          setStatus('scanning', t('statusScanning') || 'Scanning messages...');
           response = await chrome.tabs.sendMessage(tab.id, {
             action: 'CHECK_AVAILABILITY',
+            force: isForce,
+            parserMode: storedSettings.parserMode || 'auto',
           });
           activeTargetFrameId = null;
         }
@@ -260,7 +349,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           logger.info(
             `Successfully connected to platform: ${response.platform} with ${response.count} messages (frameId: ${activeTargetFrameId})`,
           );
-          statusEl.textContent = `${t('statusReady') || 'Ready'}: ${response.platform}`;
+          setStatus('ready', `${t('statusReady') || 'Ready'}: ${response.platform}`);
           const platformName = response.platform || 'AI';
           const displayTitle = resolveConversationTitle(response.title, platformName, {
             title: tab.title,
@@ -306,6 +395,24 @@ document.addEventListener('DOMContentLoaded', async () => {
       } catch (e) {
         const isNotReady = e.message && e.message.includes('Receiving end does not exist');
         logger.debug(`Attempt ${attempt + 1} communication status:`, e.message);
+        if (
+          isNotReady &&
+          attempt === 0 &&
+          typeof chrome !== 'undefined' &&
+          chrome.scripting?.executeScript
+        ) {
+          try {
+            logger.debug('Attempting on-demand script injection for tab:', tab.id);
+            await chrome.scripting.executeScript({
+              target: { tabId: tab.id },
+              files: ['content-scripts/content.js'],
+            });
+            await new Promise((resolve) => setTimeout(resolve, 200));
+            continue;
+          } catch (injectErr) {
+            logger.debug('Dynamic script injection failed:', injectErr);
+          }
+        }
         if (!isNotReady) {
           logger.debug('Unexpected error connecting to tab:', e);
           showError();
@@ -353,7 +460,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function showError() {
-    statusEl.textContent = t('statusError') || 'Not Supported';
+    setStatus('error', t('statusError') || 'Not Supported');
     errorEl.classList.remove('hidden');
     if (copilotRedirectBox) {
       const isCopilotMs = Boolean(tab?.url && tab.url.includes('copilot.microsoft.com'));
@@ -385,6 +492,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           format: formatToRequest,
           includeImages: includeImagesCheckbox.checked,
           parserMode: storedSettings.parserMode || 'auto',
+          theme: storedSettings.theme || 'system',
         });
 
         if (response && response.success) {
@@ -405,10 +513,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             url: chrome.runtime.getURL('popup/preview.html'),
           });
 
-          statusEl.textContent = t('statusExportSuccess') || 'Export Successful!';
+          setStatus('ready', t('statusExportSuccess') || 'Export Successful!');
         } else {
-          statusEl.textContent =
-            (t('statusError') || 'Export Failed') + ': ' + (response?.error || 'Unknown');
+          setStatus(
+            'error',
+            (t('statusError') || 'Export Failed') + ': ' + (response?.error || 'Unknown'),
+          );
         }
       } else {
         const response = await sendTabMessage({
@@ -422,14 +532,16 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
 
         if (response && response.success) {
-          statusEl.textContent = t('statusExportSuccess') || 'Export Successful!';
+          setStatus('ready', t('statusExportSuccess') || 'Export Successful!');
         } else {
-          statusEl.textContent =
-            (t('statusError') || 'Export Failed') + ': ' + (response?.error || 'Unknown');
+          setStatus(
+            'error',
+            (t('statusError') || 'Export Failed') + ': ' + (response?.error || 'Unknown'),
+          );
         }
       }
     } catch (e) {
-      statusEl.textContent = 'Error: ' + e.message;
+      setStatus('error', 'Error: ' + e.message);
     } finally {
       exportBtn.disabled = false;
       updateCopyButtonVisibility();
@@ -440,12 +552,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     const format = formatSelect.value;
     copyBtn.disabled = true;
     copyBtn.textContent = t('statusExporting') || 'Copying...';
+    setStatus('exporting', t('statusExporting') || 'Copying...');
 
     try {
       const response = await sendTabMessage({
         action: 'COPY_CHAT',
         format: format,
         includeImages: includeImagesCheckbox.checked,
+        theme: storedSettings.theme || 'system',
       });
 
       if (response && response.success) {
@@ -471,12 +585,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         } else {
           await navigator.clipboard.writeText(response.content);
         }
-        statusEl.textContent = t('statusCopied') || 'Copied to Clipboard!';
+        setStatus('ready', t('statusCopied') || 'Copied to clipboard!');
       } else {
-        statusEl.textContent = 'Copy Failed: ' + (response?.error || 'Unknown');
+        setStatus('error', 'Copy Failed: ' + (response?.error || 'Unknown'));
       }
     } catch (e) {
-      statusEl.textContent = 'Error: ' + e.message;
+      setStatus('error', 'Error: ' + e.message);
     } finally {
       copyBtn.disabled = false;
       copyBtn.textContent = t('copyChat') || '📋 Copy Chat';
@@ -487,6 +601,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const format = formatSelect.value;
     previewBtn.disabled = true;
     previewBtn.textContent = t('loadingContent') || 'Opening...';
+    setStatus('exporting', t('loadingContent') || 'Opening...');
 
     try {
       const formatToRequest = format === 'pdf' ? 'html' : format === 'png' ? 'markdown' : format;
@@ -516,12 +631,12 @@ document.addEventListener('DOMContentLoaded', async () => {
           url: chrome.runtime.getURL('popup/preview.html'),
         });
 
-        statusEl.textContent = t('statusOpenedInTab') || 'Opened in New Tab!';
+        setStatus('ready', t('statusOpenedInTab') || 'Opened in New Tab!');
       } else {
-        statusEl.textContent = 'Preview Failed: ' + (response?.error || 'Unknown');
+        setStatus('error', 'Preview Failed: ' + (response?.error || 'Unknown'));
       }
     } catch (e) {
-      statusEl.textContent = 'Error: ' + e.message;
+      setStatus('error', 'Error: ' + e.message);
     } finally {
       previewBtn.disabled = false;
       previewBtn.textContent = t('openInTab') || '👁️ Open in Tab';
@@ -535,6 +650,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const targetPlatform = continueTargetSelect ? continueTargetSelect.value : 'chatgpt';
       transferBtn.disabled = true;
       transferBtn.textContent = t('statusExporting') || 'Transferring...';
+      setStatus('exporting', t('statusExporting') || 'Transferring...');
 
       try {
         const response = await sendTabMessage({
@@ -549,12 +665,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             title: filenameInput ? filenameInput.value : 'AI Conversation',
             payload: response.payload,
           });
-          statusEl.textContent = `Opening ${targetPlatform}...`;
+          setStatus('ready', `Opening ${targetPlatform}...`);
         } else {
-          statusEl.textContent = 'Transfer Failed: ' + (response?.error || 'No content');
+          setStatus('error', 'Transfer Failed: ' + (response?.error || 'No content'));
         }
       } catch (e) {
-        statusEl.textContent = 'Error: ' + e.message;
+        setStatus('error', 'Error: ' + e.message);
       } finally {
         transferBtn.disabled = false;
         transferBtn.textContent = t('transferBtn') || '↗ Transfer';

--- a/popup/preview.css
+++ b/popup/preview.css
@@ -449,15 +449,17 @@ h1 {
 .preview-main {
   flex: 1;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   height: calc(100vh - 65px);
   overflow: hidden;
   box-shadow: none;
+  position: relative;
 }
 
 .code-wrapper {
   flex: 1;
   height: 100%;
+  min-width: 0;
   background-color: var(--code-bg);
   border: none;
   border-radius: 0;
@@ -561,6 +563,7 @@ code {
 .render-wrapper {
   flex: 1;
   height: 100%;
+  min-width: 0;
   background-color: var(--card-bg);
   border: none;
   border-radius: 0;

--- a/popup/preview.html
+++ b/popup/preview.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Chat Export Preview</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
+    <link rel="shortcut icon" href="/icons/favicon.ico" />
     <link rel="stylesheet" href="preview.css" />
     <script src="../content/lib/html2canvas.min.js"></script>
   </head>

--- a/popup/preview.js
+++ b/popup/preview.js
@@ -255,7 +255,56 @@ document.addEventListener('DOMContentLoaded', async () => {
     downloadBtn.innerHTML = `${svgIcon} ${label}`;
   };
 
+  const mapTabToFormatParam = (tabName) => {
+    switch (tabName) {
+      case 'markdown':
+        return 'md';
+      case 'json':
+        return 'json';
+      case 'html-render':
+        return 'html';
+      case 'html-source':
+        return 'source';
+      case 'doc':
+        return 'doc';
+      case 'png':
+        return 'png';
+      default:
+        return null;
+    }
+  };
+
+  const mapFormatParamToTab = (param) => {
+    if (!param) return null;
+    const p = String(param).trim().toLowerCase();
+    if (p === 'md' || p === 'markdown') return 'markdown';
+    if (p === 'json') return 'json';
+    if (p === 'html' || p === 'live' || p === 'html-render') return 'html-render';
+    if (p === 'source' || p === 'html-source') return 'html-source';
+    if (p === 'doc' || p === 'word') return 'doc';
+    if (p === 'png' || p === 'image') return 'png';
+    return null;
+  };
+
+  const syncUrlFormat = (tabName) => {
+    const code = mapTabToFormatParam(tabName);
+    if (!code || typeof window === 'undefined' || !window.location) return;
+    try {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('export_format') !== code) {
+        url.searchParams.set('export_format', code);
+        if (url.searchParams.has('format')) {
+          url.searchParams.delete('format');
+        }
+        window.history.replaceState(null, '', url.pathname + url.search + url.hash);
+      }
+    } catch {
+      // Ignore URL sync errors
+    }
+  };
+
   const switchTab = (tabName) => {
+    syncUrlFormat(tabName);
     const buttons = formatTabsContainer.querySelectorAll('.control-btn');
     buttons.forEach((btn) => {
       if (btn.getAttribute('data-tab') === tabName) {
@@ -395,6 +444,19 @@ document.addEventListener('DOMContentLoaded', async () => {
       initialTab = 'png';
     } else if (initialFormat === 'html' || initialFormat === 'pdf') {
       initialTab = 'html-render';
+    }
+
+    try {
+      if (typeof window !== 'undefined' && window.location && window.location.search) {
+        const searchParams = new URLSearchParams(window.location.search);
+        const urlFormat = searchParams.get('export_format') || searchParams.get('format');
+        const mappedUrlTab = mapFormatParamToTab(urlFormat);
+        if (mappedUrlTab) {
+          initialTab = mappedUrlTab;
+        }
+      }
+    } catch {
+      // Fall back to storage initialFormat
     }
 
     if (autoPrint && (initialFormat === 'pdf' || initialFormat === 'html')) {

--- a/popup/preview.js
+++ b/popup/preview.js
@@ -291,7 +291,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!code || typeof window === 'undefined' || !window.location) return;
     try {
       const url = new URL(window.location.href);
-      if (url.searchParams.get('export_format') !== code) {
+      if (url.searchParams.get('export_format') !== code || url.searchParams.has('format')) {
         url.searchParams.set('export_format', code);
         if (url.searchParams.has('format')) {
           url.searchParams.delete('format');

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -11,6 +11,32 @@
     "message": "Erkenne Chat...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Verbinde...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Nachrichten werden gescannt...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Chat neu einlesen",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$-Chat bereit zum Exportieren ($COUNT$ Nachrichten)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Bereit",
     "description": "Status shown when chat is detected"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -11,6 +11,32 @@
     "message": "Detecting...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Connecting...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Scanning messages...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Reparse Chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ chat ready to export ($COUNT$ messages)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Ready",
     "description": "Status shown when chat is detected"

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -11,6 +11,32 @@
     "message": "Detectando...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Conectando...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Escaneando mensajes...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Volver a analizar chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Chat de $PLATFORM$ listo para exportar ($COUNT$ mensajes)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Listo",
     "description": "Status shown when chat is detected"

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -11,6 +11,32 @@
     "message": "Détection en cours...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Connexion...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Analyse des messages...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Réanalyser le chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Chat $PLATFORM$ prêt à exporter ($COUNT$ messages)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Prêt",
     "description": "Status shown when chat is detected"

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -11,6 +11,32 @@
     "message": "पहचान जारी है...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "कनेक्ट हो रहा है...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "संदेश स्कैन किए जा रहे हैं...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "चैट पुन: पार्स करें",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ चैट निर्यात के लिए तैयार ($COUNT$ संदेश)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "तैयार",
     "description": "Status shown when chat is detected"

--- a/public/_locales/it/messages.json
+++ b/public/_locales/it/messages.json
@@ -11,6 +11,32 @@
     "message": "Rilevamento in corso...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Connessione in corso...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Scansione messaggi in corso...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Rianalizza chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Chat $PLATFORM$ pronta per l'esportazione ($COUNT$ messaggi)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Pronto",
     "description": "Status shown when chat is detected"

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -11,6 +11,32 @@
     "message": "検出中...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "接続中...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "メッセージをスキャン中...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "チャットを再解析",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ チャットのエクスポート準備完了 ($COUNT$ 件のメッセージ)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "準備完了",
     "description": "Status shown when chat is detected"

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -11,6 +11,32 @@
     "message": "대화 감지 중...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "연결 중...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "메시지 검사 중...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "채팅 다시 파싱",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ 채팅 내보내기 준비 완료 ($COUNT$개 메시지)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "준비 완료",
     "description": "Status shown when chat is detected"

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -11,6 +11,32 @@
     "message": "Detectando...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Conectando...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Examinando mensagens...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Reprocessar chat",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Chat do $PLATFORM$ pronto para exportar ($COUNT$ mensagens)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Pronto",
     "description": "Status shown when chat is detected"

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -11,6 +11,32 @@
     "message": "Поиск чата...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "Подключение...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "Сканирование сообщений...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "Переанализировать чат",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ Чат $PLATFORM$ готов к экспорту ($COUNT$ сообщений)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "Готово",
     "description": "Status shown when chat is detected"

--- a/public/_locales/ta/messages.json
+++ b/public/_locales/ta/messages.json
@@ -11,6 +11,32 @@
     "message": "கண்டறிகிறது...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "இணைக்கப்படுகிறது...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "செய்திகள் ஸ்கேன் செய்யப்படுகின்றன...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "அரட்டையை மீண்டும் பாகுபடுத்து",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ அரட்டை ஏற்றுமதிக்கு தயார் ($COUNT$ செய்திகள்)",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "தயார்",
     "description": "Status shown when chat is detected"

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -11,6 +11,32 @@
     "message": "正在检测...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "连接中...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "正在扫描消息...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "重新解析对话",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ 对话已准备好导出（$COUNT$ 条消息）",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "就绪",
     "description": "Status shown when chat is detected"

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -11,6 +11,32 @@
     "message": "正在偵測...",
     "description": "Status shown while detecting chat"
   },
+  "statusConnecting": {
+    "message": "連線中...",
+    "description": "Status shown while connecting to tab"
+  },
+  "statusScanning": {
+    "message": "正在掃描訊息...",
+    "description": "Status shown while scanning conversation messages"
+  },
+  "reparseChat": {
+    "message": "重新解析對話",
+    "description": "Tooltip and label for reparse button"
+  },
+  "toastChatReady": {
+    "message": "⚡ $PLATFORM$ 對話已準備好匯出（$COUNT$ 則訊息）",
+    "description": "Toast message shown on page when chat is ready for export",
+    "placeholders": {
+      "platform": {
+        "content": "$1",
+        "example": "ChatGPT"
+      },
+      "count": {
+        "content": "$2",
+        "example": "12"
+      }
+    }
+  },
   "statusReady": {
     "message": "就緒",
     "description": "Status shown when chat is detected"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"]
 }

--- a/tests/parse-cache-and-reparse.test.mjs
+++ b/tests/parse-cache-and-reparse.test.mjs
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+test('popup.html and entrypoints/popup/index.html include reparse button and status structure', () => {
+  const popupHtml = fs.readFileSync('popup/popup.html', 'utf8');
+  const indexHtml = fs.readFileSync('entrypoints/popup/index.html', 'utf8');
+
+  for (const html of [popupHtml, indexHtml]) {
+    assert.match(html, /id="reparse-btn"/, 'Must contain reparse button');
+    assert.match(html, /data-i18n-title="reparseChat"/, 'Must have reparseChat i18n title');
+    assert.match(html, /class="status-indicator/, 'Must have status indicator');
+    assert.match(html, /class="status-text"/, 'Must have status text');
+  }
+});
+
+test('popup.css contains status states, pulse animation, and spin keyframes', () => {
+  const popupCss = fs.readFileSync('popup/popup.css', 'utf8');
+  const entryCss = fs.readFileSync('entrypoints/popup/popup.css', 'utf8');
+
+  for (const css of [popupCss, entryCss]) {
+    assert.match(css, /@keyframes pulse-dot/);
+    assert.match(css, /@keyframes spin-btn/);
+    assert.match(css, /\.status\.status-connecting/);
+    assert.match(css, /\.status\.status-scanning/);
+    assert.match(css, /\.status\.status-ready/);
+    assert.match(css, /\.sidepanel-icon-btn\.spin/);
+  }
+});
+
+test('popup.js wires reparse-btn and establishes tab session port', () => {
+  const popupJs = fs.readFileSync('popup/popup.js', 'utf8');
+  const entryPopupJs = fs.readFileSync('entrypoints/popup/popup.js', 'utf8');
+
+  for (const js of [popupJs, entryPopupJs]) {
+    assert.match(js, /getElementById\(['"]reparse-btn['"]\)/);
+    assert.match(js, /reparseBtn\.addEventListener\(['"]click['"]/);
+    assert.match(js, /checkAvailability\(\{\s*force:\s*true\s*\}\)/);
+    assert.match(js, /popup-tab-session/);
+    assert.match(js, /setStatus\(/);
+  }
+});
+
+test('content script implements 90s parse cache, DOM mutation observer, and toast notification', () => {
+  const mainJs = fs.readFileSync('content/main.js', 'utf8');
+  const entryContentJs = fs.readFileSync('entrypoints/content.js', 'utf8');
+
+  for (const js of [mainJs, entryContentJs]) {
+    assert.match(js, /PARSE_CACHE_TTL_MS\s*=\s*90\s*\*\s*1000/);
+    assert.match(js, /isCacheValid/);
+    assert.match(js, /setupDomObserver/);
+    assert.match(js, /MutationObserver/);
+    assert.match(js, /popup-tab-session/);
+    assert.match(js, /showExporterToast/);
+    assert.match(js, /request\.action === ['"]CLEAR_CACHE['"]/);
+    assert.match(js, /request\.action === ['"]SHOW_TOAST['"]/);
+  }
+});
+
+test('parse cache logic behaves correctly with TTL, dirty flag, and force bypass', () => {
+  const PARSE_CACHE_TTL_MS = 90 * 1000;
+  let parseCache = null;
+
+  function isCacheValid(url, mode, force = false) {
+    if (force || !parseCache || parseCache.dirty || !parseCache.report) return false;
+    if (parseCache.url !== url) return false;
+    if (mode && parseCache.parserMode && parseCache.parserMode !== mode) return false;
+    return Date.now() - parseCache.timestamp < PARSE_CACHE_TTL_MS;
+  }
+
+  const url = 'https://chatgpt.com/c/test-chat-id';
+
+  // 1. Initial state: cache is invalid
+  assert.equal(isCacheValid(url, 'auto'), false);
+
+  // 2. Populate cache
+  parseCache = {
+    url,
+    timestamp: Date.now(),
+    parserMode: 'auto',
+    report: { available: true, platform: 'ChatGPT', count: 10 },
+    dirty: false,
+  };
+
+  // 3. Cache hit
+  assert.equal(isCacheValid(url, 'auto'), true);
+
+  // 4. Force bypass
+  assert.equal(isCacheValid(url, 'auto', true), false);
+
+  // 5. URL mismatch
+  assert.equal(isCacheValid('https://chatgpt.com/c/different-chat', 'auto'), false);
+
+  // 6. Mode mismatch
+  assert.equal(isCacheValid(url, 'dom'), false);
+
+  // 7. DOM mutation marked dirty
+  parseCache.dirty = true;
+  assert.equal(isCacheValid(url, 'auto'), false);
+
+  // 8. Expired TTL
+  parseCache.dirty = false;
+  parseCache.timestamp = Date.now() - 95000;
+  assert.equal(isCacheValid(url, 'auto'), false);
+});

--- a/tests/preview-url-format-and-selection.test.mjs
+++ b/tests/preview-url-format-and-selection.test.mjs
@@ -6,6 +6,7 @@ const previewHtml = fs.readFileSync('entrypoints/preview/index.html', 'utf8');
 const previewJs = fs.readFileSync('entrypoints/preview/preview.js', 'utf8');
 const previewCss = fs.readFileSync('entrypoints/preview/preview.css', 'utf8');
 const popupPreviewHtml = fs.readFileSync('popup/preview.html', 'utf8');
+const popupPreviewJs = fs.readFileSync('popup/preview.js', 'utf8');
 const popupPreviewCss = fs.readFileSync('popup/preview.css', 'utf8');
 const messagesJson = JSON.parse(fs.readFileSync('_locales/en/messages.json', 'utf8'));
 
@@ -57,4 +58,12 @@ test('preview script parses URL export_format parameter and synchronizes on tab 
   assert.match(previewJs, /syncUrlFormat/);
   assert.match(previewJs, /searchParams\.get\(['"]export_format['"]\)/);
   assert.match(previewJs, /history\.replaceState/);
+});
+
+test('popup preview script parses URL export_format parameter and synchronizes on tab switch', () => {
+  assert.match(popupPreviewJs, /mapTabToFormatParam/);
+  assert.match(popupPreviewJs, /mapFormatParamToTab/);
+  assert.match(popupPreviewJs, /syncUrlFormat/);
+  assert.match(popupPreviewJs, /searchParams\.get\(['"]export_format['"]\)/);
+  assert.match(popupPreviewJs, /history\.replaceState/);
 });

--- a/tests/preview-url-format-and-selection.test.mjs
+++ b/tests/preview-url-format-and-selection.test.mjs
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const previewHtml = fs.readFileSync('entrypoints/preview/index.html', 'utf8');
+const previewJs = fs.readFileSync('entrypoints/preview/preview.js', 'utf8');
+const previewCss = fs.readFileSync('entrypoints/preview/preview.css', 'utf8');
+const popupPreviewHtml = fs.readFileSync('popup/preview.html', 'utf8');
+const popupPreviewCss = fs.readFileSync('popup/preview.css', 'utf8');
+const messagesJson = JSON.parse(fs.readFileSync('_locales/en/messages.json', 'utf8'));
+
+test('preview html includes explicit favicon link tags for webextension tab rendering', () => {
+  assert.match(
+    previewHtml,
+    /<link rel="icon" type="image\/png" sizes="32x32" href="\/icons\/favicon-32x32\.png"/,
+  );
+  assert.match(
+    previewHtml,
+    /<link rel="icon" type="image\/png" sizes="16x16" href="\/icons\/favicon-16x16\.png"/,
+  );
+  assert.match(previewHtml, /<link rel="shortcut icon" href="\/icons\/favicon\.ico"/);
+  assert.match(
+    popupPreviewHtml,
+    /<link rel="icon" type="image\/png" sizes="32x32" href="\/icons\/favicon-32x32\.png"/,
+  );
+});
+
+test('preview drawer includes All, Prompts, Responses, and None selection buttons', () => {
+  assert.match(previewHtml, /id="turn-select-all-btn"/);
+  assert.match(previewHtml, /id="turn-select-prompts-btn"/);
+  assert.match(previewHtml, /id="turn-select-responses-btn"/);
+  assert.match(previewHtml, /id="turn-deselect-all-btn"/);
+
+  assert.equal(messagesJson.selectAll.message, 'All');
+  assert.equal(messagesJson.selectPrompts.message, 'Prompts');
+  assert.equal(messagesJson.selectResponses.message, 'Responses');
+  assert.equal(messagesJson.deselectAll.message, 'None');
+});
+
+test('preview script implements Prompts and Responses filtering logic', () => {
+  assert.match(previewJs, /turnSelectPromptsBtn/);
+  assert.match(previewJs, /turnSelectResponsesBtn/);
+  assert.match(previewJs, /msg\.role === 'User'/);
+  assert.match(previewJs, /msg\.role !== 'User'/);
+});
+
+test('preview layout configures side-by-side flex row layout with min-width 0', () => {
+  assert.match(previewCss, /\.preview-main\s*\{[^}]*flex-direction:\s*row;/);
+  assert.match(previewCss, /\.code-wrapper\s*\{[^}]*min-width:\s*0;/);
+  assert.match(previewCss, /\.render-wrapper\s*\{[^}]*min-width:\s*0;/);
+  assert.match(popupPreviewCss, /\.preview-main\s*\{[^}]*flex-direction:\s*row;/);
+});
+
+test('preview script parses URL export_format parameter and synchronizes on tab switch', () => {
+  assert.match(previewJs, /mapTabToFormatParam/);
+  assert.match(previewJs, /mapFormatParamToTab/);
+  assert.match(previewJs, /syncUrlFormat/);
+  assert.match(previewJs, /searchParams\.get\(['"]export_format['"]\)/);
+  assert.match(previewJs, /history\.replaceState/);
+});


### PR DESCRIPTION
## Summary of Changes

### 1. Progressive Detection & Parse Caching
- **Step-by-step detection:** Shows progressive status messages ("Connecting...", "Scanning...", "Parsing messages...", "Preparing export...") so users know detection is actively working.
- **In-Tab Parse Cache (90s TTL):** Avoids re-parsing conversations on every popup open unless the cache has expired or new messages have been appended.
- **Mutation Invalidation:** Content script monitors DOM mutations and automatically invalidates the cache when new chat turns appear.
- **Force Reparse Control (`↻`):** Added a dedicated refresh button beside the status pill in the popup header to force an immediate re-parse bypass.
- **Background Completion Toast:** When parsing finishes while the popup was closed, a unobtrusive toast notification appears on the webpage informing the user that the chat export is ready.

### 2. Preview Workspace Enhancements
- **Tab Favicon:** Added explicit `<link rel="icon">` tags to `entrypoints/preview/index.html` and `popup/preview.html` so WebExtension tabs (`moz-extension://.../preview.html`) show the extension's icon.
- **URL Query Parameter (`?export_format=...`):**
  - Supports opening format tabs directly via query params (e.g. `preview.html?export_format=md`, `?export_format=json`).
  - Synchronizes the address bar dynamically on tab switch via `history.replaceState`.
- **Side-by-Side Live Preview:** Switched `.preview-main` to a flex row layout (`min-width: 0`), keeping the rendered preview visible and dynamically updating beside the message drawer during turn selection.
- **Selection Filters:** Added dedicated filter buttons in the drawer toolbar: **All**, **Prompts** (`role === 'User'`), **Responses** (`role !== 'User'`), and **None**.

---

## Verification
- **Automated Tests:** All 179 tests pass (`npm test`), including new tests in `tests/parse-cache-and-reparse.test.mjs` and `tests/preview-url-format-and-selection.test.mjs`.
- **Linting & Code Style:** `npm run lint` and `npm run format:check` pass cleanly.
- **Builds:** Both Chrome MV3 (`npm run build`) and Firefox MV3 (`npm run build:firefox`) succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer connection, scanning, ready, and error status indicators with progress feedback.
  * Added a **Reparse Chat** action for manually refreshing chat detection.
  * Added faster repeat scans through temporary result caching, with automatic refresh when chat content changes.
  * Added Prompts and Responses selection shortcuts in the preview.
  * Preview tabs now stay synchronised with the selected export format in the URL.
  * Added side-by-side preview panes and favicons.
* **Localisation**
  * Added translated status, reparse, and chat-ready messages across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->