### PR TITLE
feat(web): add JobFoundry-style wave background

### DIFF
--- a/web/src/components/WaveBackground.astro
+++ b/web/src/components/WaveBackground.astro
@@ -1,0 +1,188 @@
+---
+// Wave background — cloned geometry/animation from JobFoundry BackgroundGrid.
+// Colour-only adaptation for AI Chat Exporter (blue primary + violet accent).
+// Theme adapter covers class-based (.dark/.light) + system preference.
+---
+
+<div class="fixed-bg-layer" aria-hidden="true">
+  <div class="fixed-bg-grid"></div>
+  <div class="fixed-bg-wave">
+    <canvas id="ace-wave" class="bg-telemetry-canvas"></canvas>
+  </div>
+</div>
+
+<style>
+  .fixed-bg-layer {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .fixed-bg-grid {
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(to right, var(--wave-grid, rgba(15, 23, 42, 0.065)) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--wave-grid, rgba(15, 23, 42, 0.065)) 1px, transparent 1px);
+    background-size: 40px 40px;
+    background-position: center top;
+  }
+
+  html.dark .fixed-bg-grid {
+    background-image:
+      linear-gradient(to right, rgba(148, 163, 184, 0.075) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(148, 163, 184, 0.075) 1px, transparent 1px);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    html:not(.light):not(.dark) .fixed-bg-grid {
+      background-image:
+        linear-gradient(to right, rgba(148, 163, 184, 0.075) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(148, 163, 184, 0.075) 1px, transparent 1px);
+    }
+  }
+
+  .fixed-bg-wave {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 100px;
+    transform: translateY(-50%);
+    opacity: 0.7;
+  }
+
+  .bg-telemetry-canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  :global(body) {
+    position: relative;
+  }
+
+  :global(header),
+  :global(main),
+  :global(footer) {
+    position: relative;
+    z-index: 1;
+  }
+</style>
+
+<script is:inline>
+  (function () {
+    function isDark() {
+      var el = document.documentElement;
+      var attr = el.getAttribute('data-theme');
+      if (attr === 'dark') return true;
+      if (attr === 'light') return false;
+      if (el.classList.contains('dark')) return true;
+      if (el.classList.contains('light')) return false;
+      try {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches;
+      } catch (e) {
+        return false;
+      }
+    }
+
+    function setupAceWave() {
+      var canvas = document.getElementById('ace-wave');
+      if (!canvas) return;
+      if (canvas.dataset.waveInit === '1') return;
+      canvas.dataset.waveInit = '1';
+      var ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      var width = 0;
+      var height = 0;
+      var time = 0;
+      var animId = 0;
+
+      function resize() {
+        var dpr = Math.min(window.devicePixelRatio || 1, 2);
+        width = canvas.offsetWidth;
+        height = canvas.offsetHeight;
+        canvas.width = Math.floor(width * dpr);
+        canvas.height = Math.floor(height * dpr);
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      }
+
+      function drawFrame() {
+        ctx.clearRect(0, 0, width, height);
+        var dark = isDark();
+
+        ctx.strokeStyle = dark ? 'rgba(148, 163, 184, 0.09)' : 'rgba(15, 23, 42, 0.07)';
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(0, height / 2);
+        ctx.lineTo(width, height / 2);
+        ctx.stroke();
+
+        ctx.strokeStyle = dark ? 'rgba(167, 139, 250, 0.35)' : 'rgba(139, 92, 246, 0.28)';
+        ctx.lineWidth = 1.2;
+        ctx.beginPath();
+        for (var x = 0; x <= width; x += 3) {
+          var y =
+            height / 2 +
+            Math.sin(x * 0.005 - time * 0.8) * 22 +
+            Math.cos(x * 0.012 + time * 1.2) * 10;
+          if (x === 0) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        }
+        ctx.stroke();
+
+        ctx.strokeStyle = dark ? 'rgba(147, 197, 253, 0.65)' : 'rgba(59, 130, 246, 0.55)';
+        ctx.lineWidth = 1.8;
+        ctx.beginPath();
+        for (var x2 = 0; x2 <= width; x2 += 2) {
+          var y2 =
+            height / 2 +
+            Math.sin(x2 * 0.007 + time) * 26 +
+            Math.sin(x2 * 0.018 + time * 1.5) * 12;
+          if (x2 === 0) ctx.moveTo(x2, y2);
+          else ctx.lineTo(x2, y2);
+        }
+        ctx.stroke();
+      }
+
+      function animate() {
+        if (!document.hidden) {
+          drawFrame();
+          time += 0.035;
+        }
+        animId = requestAnimationFrame(animate);
+      }
+
+      window.addEventListener('resize', resize);
+      document.addEventListener('visibilitychange', function () {
+        if (!document.hidden && !animId) animate();
+      });
+      document.addEventListener('astro:page-load', function () {
+        resize();
+      });
+      resize();
+
+      try {
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+          drawFrame();
+          return;
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      animate();
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setupAceWave);
+    } else {
+      setupAceWave();
+    }
+    document.addEventListener('astro:page-load', setupAceWave);
+  })();
+</script>

--- a/web/src/components/WaveBackground.astro
+++ b/web/src/components/WaveBackground.astro
@@ -32,14 +32,14 @@
     background-position: center top;
   }
 
-  html.dark .fixed-bg-grid {
+  :global(html.dark) .fixed-bg-grid {
     background-image:
       linear-gradient(to right, rgba(148, 163, 184, 0.075) 1px, transparent 1px),
       linear-gradient(to bottom, rgba(148, 163, 184, 0.075) 1px, transparent 1px);
   }
 
   @media (prefers-color-scheme: dark) {
-    html:not(.light):not(.dark) .fixed-bg-grid {
+    :global(html:not(.light):not(.dark)) .fixed-bg-grid {
       background-image:
         linear-gradient(to right, rgba(148, 163, 184, 0.075) 1px, transparent 1px),
         linear-gradient(to bottom, rgba(148, 163, 184, 0.075) 1px, transparent 1px);
@@ -102,6 +102,12 @@
       var height = 0;
       var time = 0;
       var animId = 0;
+      var reducedMotion = false;
+      try {
+        reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      } catch (e) {
+        /* ignore */
+      }
 
       function resize() {
         var dpr = Math.min(window.devicePixelRatio || 1, 2);
@@ -110,6 +116,7 @@
         canvas.width = Math.floor(width * dpr);
         canvas.height = Math.floor(height * dpr);
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        if (reducedMotion) drawFrame();
       }
 
       function drawFrame() {
@@ -141,9 +148,7 @@
         ctx.beginPath();
         for (var x2 = 0; x2 <= width; x2 += 2) {
           var y2 =
-            height / 2 +
-            Math.sin(x2 * 0.007 + time) * 26 +
-            Math.sin(x2 * 0.018 + time * 1.5) * 12;
+            height / 2 + Math.sin(x2 * 0.007 + time) * 26 + Math.sin(x2 * 0.018 + time * 1.5) * 12;
           if (x2 === 0) ctx.moveTo(x2, y2);
           else ctx.lineTo(x2, y2);
         }
@@ -160,20 +165,16 @@
 
       window.addEventListener('resize', resize);
       document.addEventListener('visibilitychange', function () {
-        if (!document.hidden && !animId) animate();
+        if (!reducedMotion && !document.hidden && !animId) animate();
       });
       document.addEventListener('astro:page-load', function () {
         resize();
       });
       resize();
 
-      try {
-        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-          drawFrame();
-          return;
-        }
-      } catch (e) {
-        /* ignore */
+      if (reducedMotion) {
+        drawFrame();
+        return;
       }
       animate();
     }

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
-// Shared document shell: head, meta, fonts, CSS, theme bootstrap, analytics.
+ // Shared document shell: head, meta, fonts, CSS, theme bootstrap, analytics.
+import WaveBackground from '../components/WaveBackground.astro';
 export interface SeoJsonLd {
   [key: string]: unknown;
   '@type'?: string;
@@ -117,6 +118,7 @@ const jsonLdArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
     {includeAnalytics && <script defer src="https://covai.org/analytics.js"></script>}
   </head>
   <body>
+    <WaveBackground />
     <slot />
   </body>
 </html>

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
- // Shared document shell: head, meta, fonts, CSS, theme bootstrap, analytics.
+// Shared document shell: head, meta, fonts, CSS, theme bootstrap, analytics.
 import WaveBackground from '../components/WaveBackground.astro';
 export interface SeoJsonLd {
   [key: string]: unknown;


### PR DESCRIPTION
Clones the JobFoundry BackgroundGrid geometry/animation (40px grid plus dual sine-wave canvas band) with colour-only adaptation to the exporter blue/violet brand.

- New `web/src/components/WaveBackground.astro`, mounted in `BaseLayout`
- Theme adapter covers class-based and system preference; static frame under prefers-reduced-motion; pauses when tab hidden
- Verified with `npx astro build` (27 pages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an animated wave background with a subtle grid effect across the site.
  * Background colours automatically adapt to light and dark themes, including system preferences.
  * Animation pauses when the page is hidden and displays a static frame when reduced motion is enabled.
  * The background remains fixed and non-interactive while page content stays accessible above it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->